### PR TITLE
Fix Livewire profile component browser event dispatch

### DIFF
--- a/app/Livewire/Admin/Profile.php
+++ b/app/Livewire/Admin/Profile.php
@@ -52,10 +52,7 @@ class Profile extends Component
             $message = 'Profile updated successfully!';
 
             session()->flash('message', $message);
-            $this->dispatchBrowserEvent('showToastr', [
-                'type'    => 'success',
-                'message' => $message,
-            ]);
+            $this->dispatch('showToastr', type: 'success', message: $message);
         }
     }
     public function render()


### PR DESCRIPTION
## Summary
- update the admin profile Livewire component to use Livewire v3's dispatch helper when raising the showToastr browser event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d707cb059c832ea5e7a9be764c31c2