### PR TITLE
Fix avatar replacement by deleting previous file

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -30,6 +30,12 @@ class ProfileController extends Controller
 
         // Handle profile photo upload
         if ($request->hasFile('avatar')) {
+            $previousAvatar = $user->getRawOriginal('avatar');
+
+            if ($previousAvatar && Storage::disk('public')->exists($previousAvatar)) {
+                Storage::disk('public')->delete($previousAvatar);
+            }
+
             $path = $request->file('avatar')->store('profiles', 'public');
             $user->avatar = $path;
         }
@@ -52,8 +58,10 @@ class ProfileController extends Controller
         $user = auth()->user();
 
         // delete old avatar if exists
-        if ($user->avatar && Storage::disk('public')->exists($user->avatar)) {
-            Storage::disk('public')->delete($user->avatar);
+        $previousAvatar = $user->getRawOriginal('avatar');
+
+        if ($previousAvatar && Storage::disk('public')->exists($previousAvatar)) {
+            Storage::disk('public')->delete($previousAvatar);
         }
 
         // store new one


### PR DESCRIPTION
## Summary
- delete an existing avatar file before saving a new one during profile updates
- reuse the raw stored avatar path so the correct file is removed when replacing the image

## Testing
- php artisan test *(fails: vendor autoloader missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d70b42e594832ebc97a8c543aaec64