### PR TITLE
Refresh authenticated user after profile update

### DIFF
--- a/app/Livewire/Admin/Profile.php
+++ b/app/Livewire/Admin/Profile.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Admin;
 
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class Profile extends Component
@@ -53,6 +54,7 @@ class Profile extends Component
         $updated = $user->save();
 
         if ($updated) {
+            Auth::setUser($user->fresh());
             sleep(0.5);
 
             $message = 'Profile updated successfully!';


### PR DESCRIPTION
## Summary
- refresh the authenticated user instance after saving personal info updates so the top bar reflects the new data immediately

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d74f860824832692fbadfcbfa24cb8