### PR TITLE
Ensure avatar filenames always include an extension

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -43,7 +43,17 @@ class AdminController extends Controller
         $path = 'images/users';
         $file = $request->file('avatar');
         $old_picture = $user->getAttributes()['avatar'];
-        $filename = 'IMG_'.uniqid().'.'.$file->getClientOriginalExtension();
+        $extension = $file->getClientOriginalExtension();
+
+        if (empty($extension)) {
+            $extension = $file->extension();
+        }
+
+        if (empty($extension)) {
+            $extension = 'jpg';
+        }
+
+        $filename = 'IMG_'.uniqid().'.'.strtolower($extension);
 
         $upload = Kropify::getFile($file, $filename)
             ->setDisk('public')


### PR DESCRIPTION
## Summary
- add fallback logic when generating avatar filenames so uploads retain an extension

## Testing
- php artisan test *(fails: missing vendor autoload files in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d766dc48008326944077a2d03697f7