### PR TITLE
Fix avatar upload feedback and header preview refresh

### DIFF
--- a/resources/views/back/layout/pages-layout.blade.php
+++ b/resources/views/back/layout/pages-layout.blade.php
@@ -324,7 +324,7 @@
                     </ul><!-- /.nav -->
                     <!-- .btn-account -->
                     <div class="dropdown d-none d-md-flex">
-                        <button class="btn-account" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="user-avatar user-avatar-md"><img src="{{ auth()->user()->avatar }}" alt=""></span>
+                        <button class="btn-account" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="user-avatar user-avatar-md"><img src="{{ auth()->user()->avatar }}" alt="" id="topbarUserAvatar"></span>
                             <span class="account-summary pr-lg-4 d-none d-lg-block"><span class="account-name">{{ auth()->user()->name }}</span> <span class="account-description">{{ auth()->user()->type }}</span></span></button> <!-- .dropdown-menu -->
                         <div class="dropdown-menu">
                             <div class="dropdown-arrow d-lg-none" x-arrow=""></div>


### PR DESCRIPTION
## Summary
- correct the profile avatar upload script to hook into the right input, show toastr notifications, and guard against empty selections
- update the header avatar image source when an upload succeeds so the new image is shown immediately

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d768c0afc083269223159ce01ebbc2