### PR TITLE
Fix profile avatar upload feedback

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -65,6 +65,8 @@ class AdminController extends Controller
             }
 
             $user->update(['avatar' => $path . '/' . $filename]);
+            $user->refresh();
+            Auth::setUser($user);
 
             return response()->json([
                 'status'=>1,

--- a/resources/views/back/pages/auth/profile.blade.php
+++ b/resources/views/back/pages/auth/profile.blade.php
@@ -26,9 +26,57 @@
                 // toastr.error(msg);
             },
             onDone: function(response){
-                // alert(response.message);
-                console.log(response);
-                // toastr.success(response.message);
+                try {
+                    if (typeof response === 'string') {
+                        response = JSON.parse(response);
+                    }
+                } catch (error) {
+                    console.error('Failed to parse avatar upload response.', error);
+                    if (typeof window.toastr !== 'undefined') {
+                        window.toastr.error('Something went wrong while updating your profile picture.');
+                    } else {
+                        alert('Something went wrong while updating your profile picture.');
+                    }
+                    return;
+                }
+
+                const status = Number(response?.status ?? 0);
+                const message = response?.message ?? 'Profile updated.';
+                const avatarUrl = response?.avatar_url ?? null;
+
+                if (status === 1) {
+                    const cacheBustedUrl = avatarUrl
+                        ? `${avatarUrl}${avatarUrl.includes('?') ? '&' : '?'}v=${Date.now()}`
+                        : null;
+
+                    if (cacheBustedUrl) {
+                        const previewImage = document.getElementById('profilePicturePreview');
+                        if (previewImage) {
+                            previewImage.setAttribute('src', cacheBustedUrl);
+                        }
+
+                        const topbarAvatar = document.getElementById('topbarUserAvatar');
+                        if (topbarAvatar) {
+                            topbarAvatar.setAttribute('src', cacheBustedUrl);
+                        }
+                    }
+
+                    if (typeof Livewire !== 'undefined' && typeof Livewire.dispatch === 'function') {
+                        Livewire.dispatch('topbarUserAvatar');
+                    }
+
+                    if (typeof window.toastr !== 'undefined') {
+                        window.toastr.success(message);
+                    } else {
+                        alert(message);
+                    }
+                } else {
+                    if (typeof window.toastr !== 'undefined') {
+                        window.toastr.error(message);
+                    } else {
+                        alert(message);
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- refresh the authenticated user instance after saving a new avatar
- enhance the profile upload callback to update the preview/topbar avatar and display success or error toasts

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d773a048508326977670cab96a4bd0