### PR TITLE
Enhance admin settings with branding controls

### DIFF
--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -3,11 +3,15 @@
 namespace App\Livewire\Admin;
 
 use Livewire\Component;
+use Livewire\WithFileUploads;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use App\Models\GeneralSetting;
 
 class Settings extends Component
 {
+    use WithFileUploads;
+
     public $tab = 'general_settings';
 
     protected $queryString = [
@@ -15,7 +19,17 @@ class Settings extends Component
     ];
 
     //General settings form properties
-    public $site_title, $site_email, $site_description, $site_phone, $site_meta_keywords, $site_meta_description, $site_logo, $site_favicon, $site_copyright;
+    public $site_title,
+        $site_email,
+        $site_description,
+        $site_phone,
+        $site_meta_keywords,
+        $site_meta_description,
+        $site_logo_path,
+        $site_favicon_path,
+        $site_copyright,
+        $site_logo_upload,
+        $site_favicon_upload;
 
 
     public function selectTab($tab)
@@ -28,15 +42,15 @@ class Settings extends Component
 
         //Populate General Settings
         $settings = GeneralSetting::take(1)->first();
-        if( !is_null($settings)){
+        if (! is_null($settings)) {
             $this->site_title = $settings->site_title;
             $this->site_email = $settings->site_email;
             $this->site_description = $settings->site_description;
             $this->site_phone = $settings->site_phone;
             $this->site_meta_keywords = $settings->site_meta_keywords;
             $this->site_meta_description = $settings->site_meta_description;
-            $this->site_logo = $settings->site_logo;
-            $this->site_favicon = $settings->site_favicon;
+            $this->site_logo_path = $settings->site_logo;
+            $this->site_favicon_path = $settings->site_favicon;
             $this->site_copyright = $settings->site_copyright;
         }
     }
@@ -44,32 +58,81 @@ class Settings extends Component
     public function updateSiteInfo()
     {
         $this->validate([
-            'site_title' => 'required',
-            'site_email' => 'required',
+            'site_title' => 'required|string|max:255',
+            'site_email' => 'required|email|max:255',
+            'site_description' => 'nullable|string|max:500',
+            'site_phone' => 'nullable|string|max:50',
+            'site_meta_keywords' => 'nullable|string|max:255',
+            'site_meta_description' => 'nullable|string|max:500',
+            'site_copyright' => 'nullable|string|max:255',
         ]);
-        $settings = GeneralSetting::take(1)->first();
-        $data = array(
+
+        $settings = GeneralSetting::first();
+        $data = [
             'site_title' => $this->site_title,
             'site_email' => $this->site_email,
             'site_description' => $this->site_description,
             'site_phone' => $this->site_phone,
             'site_meta_keywords' => $this->site_meta_keywords,
             'site_meta_description' => $this->site_meta_description,
-            'site_logo' => $this->site_logo,
-            'site_favicon' => $this->site_favicon,
             'site_copyright' => $this->site_copyright,
-        );
-        if(!is_null($settings)){
-            $query = $settings->update($data);
+        ];
+
+        $query = $settings ? $settings->update($data) : GeneralSetting::create($data);
+
+        if ($query) {
+            $this->dispatch('showToastr', ['type' => 'success', 'message' => 'General Setting Updated Successfully']);
         } else {
-            $query = GeneralSetting::insert($data);
+            $this->dispatch('showToastr', ['type' => 'error', 'message' => 'General Setting Not Updated']);
+        }
+    }
+
+    public function updateBranding()
+    {
+        $this->validate([
+            'site_logo_upload' => 'nullable|image|mimes:png,jpg,jpeg,svg,webp|max:2048',
+            'site_favicon_upload' => 'nullable|image|mimes:png,jpg,jpeg,ico,svg,webp|max:1024',
+        ]);
+
+        $settings = GeneralSetting::first();
+
+        if (! $settings) {
+            $settings = GeneralSetting::create([]);
         }
 
-        if($query){
-            $this->dispatch('showToastr', ['type'=> 'success', 'message' => 'General Setting Updated Successfully']);
-        } else {
-            $this->dispatch('showToastr', ['type'=> 'error', 'message' => 'General Setting Not Updated']);
+        $data = [];
+
+        if ($this->site_logo_upload) {
+            $path = $this->site_logo_upload->store('settings', 'public');
+
+            if ($this->site_logo_path && Storage::disk('public')->exists($this->site_logo_path)) {
+                Storage::disk('public')->delete($this->site_logo_path);
+            }
+
+            $data['site_logo'] = $path;
+            $this->site_logo_path = $path;
+            $this->site_logo_upload = null;
         }
+
+        if ($this->site_favicon_upload) {
+            $path = $this->site_favicon_upload->store('settings', 'public');
+
+            if ($this->site_favicon_path && Storage::disk('public')->exists($this->site_favicon_path)) {
+                Storage::disk('public')->delete($this->site_favicon_path);
+            }
+
+            $data['site_favicon'] = $path;
+            $this->site_favicon_path = $path;
+            $this->site_favicon_upload = null;
+        }
+
+        if (! empty($data)) {
+            $settings->update($data);
+            $this->dispatch('showToastr', ['type' => 'success', 'message' => 'Branding updated successfully']);
+            return;
+        }
+
+        $this->dispatch('showToastr', ['type' => 'info', 'message' => 'Please upload a logo or favicon to update branding']);
     }
 
     public function render()

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -52,41 +52,53 @@
                         <div class="tab-pane {{ $tab == 'general_settings' ? 'active show' : '' }}" id="general_settings">
                             <h6>GENERAL SETTINGS</h6>
                             <hr>
-                            <form wire:submit="updateSiteInfo()">
+                            <form wire:submit.prevent="updateSiteInfo()">
                                 <div class="row">
                                     <div class="col-md-6">
                                         <div class="form-group">
                                             <label for=""><b>Site title</b></label>
-                                            <input type="text" class="form-control" wire:model="site_title" placeholder="Enter site title">
+                                            <input type="text" class="form-control" wire:model.defer="site_title" placeholder="Enter site title">
                                             @error('site_title')<span class="text-danger">{{ $message }}</span>@enderror
                                         </div>
                                     </div>
                                     <div class="col-md-6">
                                         <div class="form-group">
                                             <label for=""><b>Site email</b></label>
-                                            <input type="text" class="form-control" wire:model="site_email" placeholder="Enter site email">
+                                            <input type="email" class="form-control" wire:model.defer="site_email" placeholder="Enter site email">
                                             @error('site_email')<span class="text-danger">{{ $message }}</span>@enderror
+                                        </div>
+                                    </div>
+                                    <div class="col-md-12">
+                                        <div class="form-group">
+                                            <label for=""><b>Site description</b> <small>(Optional)</small></label>
+                                            <textarea class="form-control" rows="3" wire:model.defer="site_description" placeholder="Write a short description about your site..."></textarea>
+                                            @error('site_description')<span class="text-danger">{{ $message }}</span>@enderror
                                         </div>
                                     </div>
                                     <div class="col-md-6">
                                         <div class="form-group">
                                             <label for=""><b>Site phone number</b></label>
-                                            <input type="text" class="form-control" wire:model="site_phone" placeholder="Enter site contact phone">
+                                            <input type="text" class="form-control" wire:model.defer="site_phone" placeholder="Enter site contact phone">
                                             @error('site_phone')<span class="text-danger">{{ $message }}</span>@enderror
                                         </div>
                                     </div>
                                     <div class="col-md-6">
                                         <div class="form-group">
                                             <label for=""><b>Site Meta keywords</b> <small>(Optional)</small></label>
-                                            <input type="text" class="form-control" wire:model="site_meta_keywords" placeholder="Eg: ecommerce, free api, laravel">
+                                            <input type="text" class="form-control" wire:model.defer="site_meta_keywords" placeholder="Eg: ecommerce, free api, laravel">
                                             @error('site_meta_keywords')<span class="text-danger">{{ $message }}</span>@enderror
                                         </div>
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <label for=""><b>Site Meta Description</b> <small>(Optional)</small></label>
-                                    <textarea class="form-control" cols="4" rows="4" name="site_meta_description" placeholder="Type site meta description..."></textarea>
+                                    <textarea class="form-control" cols="4" rows="4" wire:model.defer="site_meta_description" placeholder="Type site meta description..."></textarea>
                                     @error('site_meta_description')<span class="text-danger">{{ $message }}</span>@enderror
+                                </div>
+                                <div class="form-group">
+                                    <label for=""><b>Site Copyright text</b> <small>(Optional)</small></label>
+                                    <input type="text" class="form-control" wire:model.defer="site_copyright" placeholder="Eg: © {{ date('Y') }} LaraBlog. All rights reserved.">
+                                    @error('site_copyright')<span class="text-danger">{{ $message }}</span>@enderror
                                 </div>
                                 <button type="submit" class="btn btn-primary">Save changes</button>
                             </form>
@@ -95,7 +107,49 @@
                         <div class="tab-pane {{ $tab == 'logo_favicon' ? 'active show' : '' }}" id="logo_favicon">
                             <h6>LOGO & FAVICON</h6>
                             <hr>
-                            <p>Content for logo & favicon goes here...</p>
+                            <form wire:submit.prevent="updateBranding()">
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="form-group">
+                                            <label for=""><b>Site logo</b></label>
+                                            <input type="file" class="form-control-file" wire:model="site_logo_upload" accept="image/*">
+                                            <small class="form-text text-muted">Upload PNG, JPG, SVG or WEBP image up to 2MB.</small>
+                                            @error('site_logo_upload')<span class="text-danger">{{ $message }}</span>@enderror
+                                        </div>
+                                        @if ($site_logo_upload)
+                                            <div class="border rounded p-2 text-center">
+                                                <small class="d-block text-muted mb-2">Preview</small>
+                                                <img src="{{ $site_logo_upload->temporaryUrl() }}" alt="Site logo preview" class="img-fluid" style="max-height: 120px;">
+                                            </div>
+                                        @elseif ($site_logo_path)
+                                            <div class="border rounded p-2 text-center">
+                                                <small class="d-block text-muted mb-2">Current logo</small>
+                                                <img src="{{ asset('storage/' . $site_logo_path) }}" alt="Current site logo" class="img-fluid" style="max-height: 120px;">
+                                            </div>
+                                        @endif
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-group">
+                                            <label for=""><b>Site favicon</b></label>
+                                            <input type="file" class="form-control-file" wire:model="site_favicon_upload" accept="image/*">
+                                            <small class="form-text text-muted">Upload PNG, JPG, ICO, SVG or WEBP image up to 1MB.</small>
+                                            @error('site_favicon_upload')<span class="text-danger">{{ $message }}</span>@enderror
+                                        </div>
+                                        @if ($site_favicon_upload)
+                                            <div class="border rounded p-2 text-center">
+                                                <small class="d-block text-muted mb-2">Preview</small>
+                                                <img src="{{ $site_favicon_upload->temporaryUrl() }}" alt="Site favicon preview" class="img-fluid" style="max-height: 80px; width: auto;">
+                                            </div>
+                                        @elseif ($site_favicon_path)
+                                            <div class="border rounded p-2 text-center">
+                                                <small class="d-block text-muted mb-2">Current favicon</small>
+                                                <img src="{{ asset('storage/' . $site_favicon_path) }}" alt="Current site favicon" class="img-fluid" style="max-height: 80px; width: auto;">
+                                            </div>
+                                        @endif
+                                    </div>
+                                </div>
+                                <button type="submit" class="btn btn-primary">Update branding</button>
+                            </form>
                         </div>
 
                         <div class="tab-pane {{ $tab == 'security_settings' ? 'active show' : '' }}" id="security_settings">


### PR DESCRIPTION
## Summary
- bind general settings fields to Livewire state and add description and copyright inputs
- implement logo and favicon upload workflow with previews and validation
- persist branding assets via Livewire component using storage-backed uploads

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d96b6b1278832684b02df5e1420fa2