### PR TITLE
Add admin CRUD for categories and subcategories

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class CategoryController extends Controller
+{
+    public function index(): View
+    {
+        $categories = Category::withCount('subCategories')->latest()->paginate(15);
+
+        return view('back.pages.categories.index', [
+            'pageTitle' => 'Categories',
+            'categories' => $categories,
+        ]);
+    }
+
+    public function create(): View
+    {
+        return view('back.pages.categories.create', [
+            'pageTitle' => 'Create Category',
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'image' => ['nullable', 'image', 'max:2048'],
+        ]);
+
+        $slug = Str::slug($validated['slug'] ?? $validated['name']);
+        if (empty($slug)) {
+            $slug = Str::random(8);
+        }
+        $slug = $this->makeUniqueSlug($slug);
+
+        $imagePath = null;
+        if ($request->hasFile('image')) {
+            $imagePath = $request->file('image')->store('categories', 'public');
+        }
+
+        Category::create([
+            'name' => $validated['name'],
+            'slug' => $slug,
+            'description' => $validated['description'] ?? null,
+            'image_path' => $imagePath,
+        ]);
+
+        return redirect()->route('admin.categories.index')->with('success', 'Category created successfully.');
+    }
+
+    public function edit(Category $category): View
+    {
+        return view('back.pages.categories.edit', [
+            'pageTitle' => 'Edit Category',
+            'category' => $category,
+        ]);
+    }
+
+    public function update(Request $request, Category $category): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'image' => ['nullable', 'image', 'max:2048'],
+        ]);
+
+        $slug = Str::slug($validated['slug'] ?? $validated['name']);
+        if (empty($slug)) {
+            $slug = Str::random(8);
+        }
+        $slug = $this->makeUniqueSlug($slug, $category->id);
+
+        $imagePath = $category->image_path;
+        if ($request->hasFile('image')) {
+            if ($imagePath && Storage::disk('public')->exists($imagePath)) {
+                Storage::disk('public')->delete($imagePath);
+            }
+            $imagePath = $request->file('image')->store('categories', 'public');
+        }
+
+        $category->update([
+            'name' => $validated['name'],
+            'slug' => $slug,
+            'description' => $validated['description'] ?? null,
+            'image_path' => $imagePath,
+        ]);
+
+        return redirect()->route('admin.categories.index')->with('success', 'Category updated successfully.');
+    }
+
+    public function destroy(Category $category): RedirectResponse
+    {
+        if ($category->image_path && Storage::disk('public')->exists($category->image_path)) {
+            Storage::disk('public')->delete($category->image_path);
+        }
+
+        $category->delete();
+
+        return redirect()->route('admin.categories.index')->with('success', 'Category deleted successfully.');
+    }
+
+    protected function makeUniqueSlug(string $baseSlug, ?int $ignoreId = null): string
+    {
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while ($this->slugExists($slug, $ignoreId)) {
+            $slug = $baseSlug.'-'.$counter++;
+        }
+
+        return $slug;
+    }
+
+    protected function slugExists(string $slug, ?int $ignoreId = null): bool
+    {
+        return Category::where('slug', $slug)
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->exists();
+    }
+}

--- a/app/Http/Controllers/Admin/SubCategoryController.php
+++ b/app/Http/Controllers/Admin/SubCategoryController.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\SubCategory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class SubCategoryController extends Controller
+{
+    public function index(): View
+    {
+        $subCategories = SubCategory::with('category')->latest()->paginate(15);
+
+        return view('back.pages.sub_categories.index', [
+            'pageTitle' => 'Sub Categories',
+            'subCategories' => $subCategories,
+        ]);
+    }
+
+    public function create(): View
+    {
+        return view('back.pages.sub_categories.create', [
+            'pageTitle' => 'Create Sub Category',
+            'categories' => Category::orderBy('name')->pluck('name', 'id'),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'category_id' => ['required', 'exists:categories,id'],
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'image' => ['nullable', 'image', 'max:2048'],
+        ]);
+
+        $slug = Str::slug($validated['slug'] ?? $validated['name']);
+        if (empty($slug)) {
+            $slug = Str::random(8);
+        }
+        $slug = $this->makeUniqueSlug($slug);
+
+        $imagePath = null;
+        if ($request->hasFile('image')) {
+            $imagePath = $request->file('image')->store('sub-categories', 'public');
+        }
+
+        SubCategory::create([
+            'category_id' => $validated['category_id'],
+            'name' => $validated['name'],
+            'slug' => $slug,
+            'description' => $validated['description'] ?? null,
+            'image_path' => $imagePath,
+        ]);
+
+        return redirect()->route('admin.subcategories.index')->with('success', 'Sub category created successfully.');
+    }
+
+    public function edit(SubCategory $subcategory): View
+    {
+        return view('back.pages.sub_categories.edit', [
+            'pageTitle' => 'Edit Sub Category',
+            'subcategory' => $subcategory,
+            'categories' => Category::orderBy('name')->pluck('name', 'id'),
+        ]);
+    }
+
+    public function update(Request $request, SubCategory $subcategory): RedirectResponse
+    {
+        $validated = $request->validate([
+            'category_id' => ['required', 'exists:categories,id'],
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'image' => ['nullable', 'image', 'max:2048'],
+        ]);
+
+        $slug = Str::slug($validated['slug'] ?? $validated['name']);
+        if (empty($slug)) {
+            $slug = Str::random(8);
+        }
+        $slug = $this->makeUniqueSlug($slug, $subcategory->id);
+
+        $imagePath = $subcategory->image_path;
+        if ($request->hasFile('image')) {
+            if ($imagePath && Storage::disk('public')->exists($imagePath)) {
+                Storage::disk('public')->delete($imagePath);
+            }
+            $imagePath = $request->file('image')->store('sub-categories', 'public');
+        }
+
+        $subcategory->update([
+            'category_id' => $validated['category_id'],
+            'name' => $validated['name'],
+            'slug' => $slug,
+            'description' => $validated['description'] ?? null,
+            'image_path' => $imagePath,
+        ]);
+
+        return redirect()->route('admin.subcategories.index')->with('success', 'Sub category updated successfully.');
+    }
+
+    public function destroy(SubCategory $subcategory): RedirectResponse
+    {
+        if ($subcategory->image_path && Storage::disk('public')->exists($subcategory->image_path)) {
+            Storage::disk('public')->delete($subcategory->image_path);
+        }
+
+        $subcategory->delete();
+
+        return redirect()->route('admin.subcategories.index')->with('success', 'Sub category deleted successfully.');
+    }
+
+    protected function makeUniqueSlug(string $baseSlug, ?int $ignoreId = null): string
+    {
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while ($this->slugExists($slug, $ignoreId)) {
+            $slug = $baseSlug.'-'.$counter++;
+        }
+
+        return $slug;
+    }
+
+    protected function slugExists(string $slug, ?int $ignoreId = null): bool
+    {
+        return SubCategory::where('slug', $slug)
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->exists();
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+        'image_path',
+    ];
+
+    public function subCategories(): HasMany
+    {
+        return $this->hasMany(SubCategory::class);
+    }
+}

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SubCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'category_id',
+        'name',
+        'slug',
+        'description',
+        'image_path',
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/database/migrations/2025_09_28_170500_create_categories_table.php
+++ b/database/migrations/2025_09_28_170500_create_categories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('image_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_09_28_170600_create_sub_categories_table.php
+++ b/database/migrations/2025_09_28_170600_create_sub_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sub_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained('categories')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('image_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sub_categories');
+    }
+};

--- a/resources/views/back/layout/pages-layout.blade.php
+++ b/resources/views/back/layout/pages-layout.blade.php
@@ -376,69 +376,13 @@
                         <li class="menu-item has-active">
                             <a href="{{ route('admin.dashboard') }}" class="menu-link"><span class="menu-icon fas fa-home"></span> <span class="menu-text">Dashboard</span></a>
                         </li><!-- /.menu-item -->
-                        <!-- .menu-item -->
-                        <li class="menu-item has-child">
-                            <a href="#" class="menu-link"><span class="menu-icon far fa-file"></span> <span class="menu-text">App Pages</span> <span class="badge badge-warning">New</span></a> <!-- child menu -->
-                            <ul class="menu">
-                                <li class="menu-item">
-                                    <a href="page-clients.html" class="menu-link">Clients</a>
-                                </li>
-                                <li class="menu-item">
-                                    <a href="page-teams.html" class="menu-link">Teams</a>
-                                </li>
-                                <li class="menu-item has-child">
-                                    <a href="#" class="menu-link">Team</a> <!-- grand child menu -->
-                                    <ul class="menu">
-                                        <li class="menu-item">
-                                            <a href="page-team.html" class="menu-link">Overview</a>
-                                        </li>
-                                        <li class="menu-item">
-                                            <a href="page-team-feeds.html" class="menu-link">Feeds</a>
-                                        </li>
-                                        <li class="menu-item">
-                                            <a href="page-team-projects.html" class="menu-link">Projects</a>
-                                        </li>
-                                        <li class="menu-item">
-                                            <a href="page-team-members.html" class="menu-link">Members</a>
-                                        </li>
-                                    </ul><!-- /grand child menu -->
-                                </li>
-                                <li class="menu-item has-child">
-                                    <a href="#" class="menu-link">Project</a> <!-- grand child menu -->
-                                    <ul class="menu">
-                                        <li class="menu-item">
-                                            <a href="page-project.html" class="menu-link">Overview</a>
-                                        </li>
-                                        <li class="menu-item">
-                                            <a href="page-project-board.html" class="menu-link">Board</a>
-                                        </li>
-                                        <li class="menu-item">
-                                            <a href="page-project-gantt.html" class="menu-link">Gantt View</a>
-                                        </li>
-                                    </ul><!-- /grand child menu -->
-                                </li>
-                                <li class="menu-item">
-                                    <a href="page-calendar.html" class="menu-link">Calendar</a>
-                                </li>
-                                <li class="menu-item has-child">
-                                    <a href="#" class="menu-link">Invoices</a> <!-- grand child menu -->
-                                    <ul class="menu">
-                                        <li class="menu-item">
-                                            <a href="page-invoices.html" class="menu-link">List</a>
-                                        </li>
-                                        <li class="menu-item">
-                                            <a href="page-invoice.html" class="menu-link">Details</a>
-                                        </li>
-                                    </ul><!-- /grand child menu -->
-                                </li>
-                                <li class="menu-item">
-                                    <a href="page-messages.html" class="menu-link">Messages</a>
-                                </li>
-                                <li class="menu-item">
-                                    <a href="page-conversations.html" class="menu-link">Conversations</a>
-                                </li>
-                            </ul><!-- /child menu -->
-                        </li><!-- /.menu-item -->
+                        <li class="menu-header">Blog Management</li>
+                        <li class="menu-item {{ request()->routeIs('admin.categories.*') ? 'has-active' : '' }}">
+                            <a href="{{ route('admin.categories.index') }}" class="menu-link"><span class="menu-icon oi oi-folder"></span> <span class="menu-text">Categories</span></a>
+                        </li>
+                        <li class="menu-item {{ request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
+                            <a href="{{ route('admin.subcategories.index') }}" class="menu-link"><span class="menu-icon oi oi-layers"></span> <span class="menu-text">Sub Categories</span></a>
+                        </li>
                         <!-- .menu-item -->
                         <li class="menu-item has-child {{ request()->routeIs('admin.settings*') ? 'has-active' : '' }}">
                             <a href="#" class="menu-link"><span class="menu-icon oi oi-wrench"></span> <span class="menu-text">Setting</span></a> <!-- child menu -->

--- a/resources/views/back/pages/categories/create.blade.php
+++ b/resources/views/back/pages/categories/create.blade.php
@@ -1,0 +1,53 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Create Category')
+@section('content')
+    <header class="page-title-bar">
+        <h1 class="page-title">Create Category</h1>
+        <a href="{{ route('admin.categories.index') }}" class="btn btn-link">&larr; Back to categories</a>
+    </header>
+
+    <div class="page-section">
+        <div class="card card-fluid">
+            <div class="card-body">
+                <form action="{{ route('admin.categories.store') }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    <div class="form-group">
+                        <label for="name">Name <span class="text-danger">*</span></label>
+                        <input type="text" name="name" id="name" class="form-control @error('name') is-invalid @enderror" value="{{ old('name') }}" required>
+                        @error('name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="slug">Slug</label>
+                        <input type="text" name="slug" id="slug" class="form-control @error('slug') is-invalid @enderror" value="{{ old('slug') }}" placeholder="Leave empty to auto generate">
+                        @error('slug')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="description">Description</label>
+                        <textarea name="description" id="description" rows="4" class="form-control @error('description') is-invalid @enderror">{{ old('description') }}</textarea>
+                        @error('description')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="image">Image</label>
+                        <input type="file" name="image" id="image" class="form-control-file @error('image') is-invalid @enderror" accept="image/*">
+                        @error('image')
+                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group mb-0">
+                        <button type="submit" class="btn btn-primary">Save Category</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/categories/edit.blade.php
+++ b/resources/views/back/pages/categories/edit.blade.php
@@ -1,0 +1,62 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Edit Category')
+@section('content')
+    <header class="page-title-bar">
+        <h1 class="page-title">Edit Category</h1>
+        <a href="{{ route('admin.categories.index') }}" class="btn btn-link">&larr; Back to categories</a>
+    </header>
+
+    <div class="page-section">
+        <div class="card card-fluid">
+            <div class="card-body">
+                <form action="{{ route('admin.categories.update', $category) }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+                    <div class="form-group">
+                        <label for="name">Name <span class="text-danger">*</span></label>
+                        <input type="text" name="name" id="name" class="form-control @error('name') is-invalid @enderror" value="{{ old('name', $category->name) }}" required>
+                        @error('name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="slug">Slug</label>
+                        <input type="text" name="slug" id="slug" class="form-control @error('slug') is-invalid @enderror" value="{{ old('slug', $category->slug) }}">
+                        @error('slug')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="description">Description</label>
+                        <textarea name="description" id="description" rows="4" class="form-control @error('description') is-invalid @enderror">{{ old('description', $category->description) }}</textarea>
+                        @error('description')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="image">Image</label>
+                        <div class="mb-2">
+                            @if ($category->image_path)
+                                <img src="{{ asset('storage/' . $category->image_path) }}" alt="{{ $category->name }}" class="img-thumbnail" style="max-width: 120px;">
+                            @else
+                                <span class="text-muted">No image uploaded</span>
+                            @endif
+                        </div>
+                        <input type="file" name="image" id="image" class="form-control-file @error('image') is-invalid @enderror" accept="image/*">
+                        @error('image')
+                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                        @enderror
+                        <small class="form-text text-muted">Uploading a new image will replace the previous one.</small>
+                    </div>
+
+                    <div class="form-group mb-0">
+                        <button type="submit" class="btn btn-primary">Update Category</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/categories/index.blade.php
+++ b/resources/views/back/pages/categories/index.blade.php
@@ -1,0 +1,77 @@
+@php use Illuminate\Support\Str; @endphp
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Categories')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">Categories</h1>
+                <p class="text-muted">Manage blog categories and their basic details.</p>
+            </div>
+            <a href="{{ route('admin.categories.create') }}" class="btn btn-primary">Create Category</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+
+        <div class="card card-fluid">
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th scope="col">#</th>
+                                <th scope="col">Image</th>
+                                <th scope="col">Name</th>
+                                <th scope="col">Slug</th>
+                                <th scope="col">Sub Categories</th>
+                                <th scope="col">Updated At</th>
+                                <th scope="col" class="text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($categories as $category)
+                                <tr>
+                                    <td>{{ $loop->iteration + ($categories->currentPage() - 1) * $categories->perPage() }}</td>
+                                    <td>
+                                        @if ($category->image_path)
+                                            <img src="{{ asset('storage/' . $category->image_path) }}" alt="{{ $category->name }}" class="img-thumbnail" style="max-width: 60px;">
+                                        @else
+                                            <span class="text-muted">No image</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <strong>{{ $category->name }}</strong>
+                                        @if ($category->description)
+                                            <div class="text-muted small">{{ Str::limit($category->description, 80) }}</div>
+                                        @endif
+                                    </td>
+                                    <td><code>{{ $category->slug }}</code></td>
+                                    <td>{{ $category->sub_categories_count }}</td>
+                                    <td>{{ $category->updated_at->format('d M, Y') }}</td>
+                                    <td class="text-right">
+                                        <a href="{{ route('admin.categories.edit', $category) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                                        <form action="{{ route('admin.categories.destroy', $category) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this category?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="text-center text-muted">No categories found.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                {{ $categories->links() }}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/sub_categories/create.blade.php
+++ b/resources/views/back/pages/sub_categories/create.blade.php
@@ -1,0 +1,66 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Create Sub Category')
+@section('content')
+    <header class="page-title-bar">
+        <h1 class="page-title">Create Sub Category</h1>
+        <a href="{{ route('admin.subcategories.index') }}" class="btn btn-link">&larr; Back to sub categories</a>
+    </header>
+
+    <div class="page-section">
+        <div class="card card-fluid">
+            <div class="card-body">
+                <form action="{{ route('admin.subcategories.store') }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    <div class="form-group">
+                        <label for="category_id">Parent Category <span class="text-danger">*</span></label>
+                        <select name="category_id" id="category_id" class="form-control @error('category_id') is-invalid @enderror" required>
+                            <option value="">Select category</option>
+                            @foreach ($categories as $id => $name)
+                                <option value="{{ $id }}" @selected(old('category_id') == $id)>{{ $name }}</option>
+                            @endforeach
+                        </select>
+                        @error('category_id')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="name">Name <span class="text-danger">*</span></label>
+                        <input type="text" name="name" id="name" class="form-control @error('name') is-invalid @enderror" value="{{ old('name') }}" required>
+                        @error('name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="slug">Slug</label>
+                        <input type="text" name="slug" id="slug" class="form-control @error('slug') is-invalid @enderror" value="{{ old('slug') }}" placeholder="Leave empty to auto generate">
+                        @error('slug')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="description">Description</label>
+                        <textarea name="description" id="description" rows="4" class="form-control @error('description') is-invalid @enderror">{{ old('description') }}</textarea>
+                        @error('description')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="image">Image</label>
+                        <input type="file" name="image" id="image" class="form-control-file @error('image') is-invalid @enderror" accept="image/*">
+                        @error('image')
+                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group mb-0">
+                        <button type="submit" class="btn btn-primary">Save Sub Category</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/sub_categories/edit.blade.php
+++ b/resources/views/back/pages/sub_categories/edit.blade.php
@@ -1,0 +1,75 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Edit Sub Category')
+@section('content')
+    <header class="page-title-bar">
+        <h1 class="page-title">Edit Sub Category</h1>
+        <a href="{{ route('admin.subcategories.index') }}" class="btn btn-link">&larr; Back to sub categories</a>
+    </header>
+
+    <div class="page-section">
+        <div class="card card-fluid">
+            <div class="card-body">
+                <form action="{{ route('admin.subcategories.update', $subcategory) }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+                    <div class="form-group">
+                        <label for="category_id">Parent Category <span class="text-danger">*</span></label>
+                        <select name="category_id" id="category_id" class="form-control @error('category_id') is-invalid @enderror" required>
+                            <option value="">Select category</option>
+                            @foreach ($categories as $id => $name)
+                                <option value="{{ $id }}" @selected(old('category_id', $subcategory->category_id) == $id)>{{ $name }}</option>
+                            @endforeach
+                        </select>
+                        @error('category_id')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="name">Name <span class="text-danger">*</span></label>
+                        <input type="text" name="name" id="name" class="form-control @error('name') is-invalid @enderror" value="{{ old('name', $subcategory->name) }}" required>
+                        @error('name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="slug">Slug</label>
+                        <input type="text" name="slug" id="slug" class="form-control @error('slug') is-invalid @enderror" value="{{ old('slug', $subcategory->slug) }}">
+                        @error('slug')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="description">Description</label>
+                        <textarea name="description" id="description" rows="4" class="form-control @error('description') is-invalid @enderror">{{ old('description', $subcategory->description) }}</textarea>
+                        @error('description')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    <div class="form-group">
+                        <label for="image">Image</label>
+                        <div class="mb-2">
+                            @if ($subcategory->image_path)
+                                <img src="{{ asset('storage/' . $subcategory->image_path) }}" alt="{{ $subcategory->name }}" class="img-thumbnail" style="max-width: 120px;">
+                            @else
+                                <span class="text-muted">No image uploaded</span>
+                            @endif
+                        </div>
+                        <input type="file" name="image" id="image" class="form-control-file @error('image') is-invalid @enderror" accept="image/*">
+                        @error('image')
+                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                        @enderror
+                        <small class="form-text text-muted">Uploading a new image will replace the previous one.</small>
+                    </div>
+
+                    <div class="form-group mb-0">
+                        <button type="submit" class="btn btn-primary">Update Sub Category</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/sub_categories/index.blade.php
+++ b/resources/views/back/pages/sub_categories/index.blade.php
@@ -1,0 +1,77 @@
+@php use Illuminate\Support\Str; @endphp
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Sub Categories')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">Sub Categories</h1>
+                <p class="text-muted">Organise additional layers for your categories.</p>
+            </div>
+            <a href="{{ route('admin.subcategories.create') }}" class="btn btn-primary">Create Sub Category</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+
+        <div class="card card-fluid">
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th scope="col">#</th>
+                                <th scope="col">Image</th>
+                                <th scope="col">Name</th>
+                                <th scope="col">Parent Category</th>
+                                <th scope="col">Slug</th>
+                                <th scope="col">Updated At</th>
+                                <th scope="col" class="text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($subCategories as $subcategory)
+                                <tr>
+                                    <td>{{ $loop->iteration + ($subCategories->currentPage() - 1) * $subCategories->perPage() }}</td>
+                                    <td>
+                                        @if ($subcategory->image_path)
+                                            <img src="{{ asset('storage/' . $subcategory->image_path) }}" alt="{{ $subcategory->name }}" class="img-thumbnail" style="max-width: 60px;">
+                                        @else
+                                            <span class="text-muted">No image</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <strong>{{ $subcategory->name }}</strong>
+                                        @if ($subcategory->description)
+                                            <div class="text-muted small">{{ Str::limit($subcategory->description, 80) }}</div>
+                                        @endif
+                                    </td>
+                                    <td>{{ $subcategory->category?->name ?? '—' }}</td>
+                                    <td><code>{{ $subcategory->slug }}</code></td>
+                                    <td>{{ $subcategory->updated_at->format('d M, Y') }}</td>
+                                    <td class="text-right">
+                                        <a href="{{ route('admin.subcategories.edit', $subcategory) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                                        <form action="{{ route('admin.subcategories.destroy', $subcategory) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this sub category?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="text-center text-muted">No sub categories found.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                {{ $subCategories->links() }}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,8 @@ use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\SubCategoryController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -34,5 +36,8 @@ Route::prefix('admin')->name('admin.')->group(function () {
               Route::post('/update-profile', 'updateProfile')->name('update.profile');
               Route::get('/settings', 'generalSettings')->name('settings');
        });
+
+       Route::resource('categories', CategoryController::class)->except(['show']);
+       Route::resource('subcategories', SubCategoryController::class)->except(['show']);
     });
 });


### PR DESCRIPTION
## Summary
- add database structures and Eloquent models for blog categories and subcategories
- implement admin controllers and Blade views to manage categories, including image upload and slug handling
- register resource routes and update the admin navigation to expose the new management screens

## Testing
- not run (dependencies not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9a07e8cc08326bd04f03efcf1a35b