### PR TITLE
Add post CRUD with categories, subcategories, and CKEditor integration

### DIFF
--- a/app/Http/Controllers/PostCategoryController.php
+++ b/app/Http/Controllers/PostCategoryController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PostCategory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class PostCategoryController extends Controller
+{
+    public function index(): View
+    {
+        $categories = PostCategory::query()->withCount(['posts', 'subcategories'])->orderBy('name')->paginate(15);
+
+        return view('back.pages.post-categories.index', compact('categories'));
+    }
+
+    public function create(): View
+    {
+        return view('back.pages.post-categories.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $this->validateCategory($request);
+
+        PostCategory::create($data);
+
+        return redirect()
+            ->route('admin.post-categories.index')
+            ->with('success', 'Category created successfully.');
+    }
+
+    public function edit(PostCategory $postCategory): View
+    {
+        return view('back.pages.post-categories.edit', compact('postCategory'));
+    }
+
+    public function update(Request $request, PostCategory $postCategory): RedirectResponse
+    {
+        $data = $this->validateCategory($request, $postCategory);
+
+        $postCategory->update($data);
+
+        return redirect()
+            ->route('admin.post-categories.edit', $postCategory)
+            ->with('success', 'Category updated successfully.');
+    }
+
+    public function destroy(PostCategory $postCategory): RedirectResponse
+    {
+        $postCategory->delete();
+
+        return redirect()
+            ->route('admin.post-categories.index')
+            ->with('success', 'Category deleted successfully.');
+    }
+
+    protected function validateCategory(Request $request, ?PostCategory $category = null): array
+    {
+        $categoryId = $category?->id;
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', Rule::unique('post_categories', 'slug')->ignore($categoryId)],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $data['slug'] = $this->prepareSlug($data['slug'] ?? null, $data['name'], $categoryId);
+
+        return $data;
+    }
+
+    protected function prepareSlug(?string $slug, string $name, ?int $ignoreId = null): string
+    {
+        if (!empty($slug)) {
+            $slug = Str::slug($slug);
+            return PostCategory::generateUniqueSlug($slug, $ignoreId);
+        }
+
+        return PostCategory::generateUniqueSlug($name, $ignoreId);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Models\PostCategory;
+use App\Models\PostSubcategory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+use Illuminate\Validation\ValidationException;
+
+class PostController extends Controller
+{
+    public function index(): View
+    {
+        $posts = Post::with(['category', 'subcategory'])->latest()->paginate(12);
+
+        return view('back.pages.posts.index', compact('posts'));
+    }
+
+    public function create(): View
+    {
+        $categories = PostCategory::with('subcategories')->orderBy('name')->get();
+
+        return view('back.pages.posts.create', compact('categories'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $this->validatePost($request);
+
+        if ($request->hasFile('thumbnail')) {
+            $data['thumbnail_path'] = $request->file('thumbnail')->store('posts', 'public');
+        }
+
+        if (empty($data['excerpt'])) {
+            $data['excerpt'] = Str::limit(strip_tags($data['body']), 250) ?: null;
+        }
+
+        Post::create($data);
+
+        return redirect()
+            ->route('admin.posts.index')
+            ->with('success', 'Post created successfully.');
+    }
+
+    public function edit(Post $post): View
+    {
+        $categories = PostCategory::with('subcategories')->orderBy('name')->get();
+
+        return view('back.pages.posts.edit', compact('post', 'categories'));
+    }
+
+    public function update(Request $request, Post $post): RedirectResponse
+    {
+        $data = $this->validatePost($request, $post);
+
+        if ($request->hasFile('thumbnail')) {
+            if ($post->thumbnail_path) {
+                Storage::disk('public')->delete($post->thumbnail_path);
+            }
+
+            $data['thumbnail_path'] = $request->file('thumbnail')->store('posts', 'public');
+        }
+
+        if (empty($data['excerpt'])) {
+            $data['excerpt'] = Str::limit(strip_tags($data['body']), 250) ?: null;
+        }
+
+        $post->update($data);
+
+        return redirect()
+            ->route('admin.posts.edit', $post)
+            ->with('success', 'Post updated successfully.');
+    }
+
+    public function destroy(Post $post): RedirectResponse
+    {
+        if ($post->thumbnail_path) {
+            Storage::disk('public')->delete($post->thumbnail_path);
+        }
+
+        $post->delete();
+
+        return redirect()
+            ->route('admin.posts.index')
+            ->with('success', 'Post deleted successfully.');
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    protected function validatePost(Request $request, ?Post $post = null): array
+    {
+        $postId = $post?->id;
+
+        $data = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', Rule::unique('posts', 'slug')->ignore($postId)],
+            'post_category_id' => ['required', Rule::exists('post_categories', 'id')],
+            'post_subcategory_id' => ['nullable', Rule::exists('post_subcategories', 'id')],
+            'excerpt' => ['nullable', 'string', 'max:500'],
+            'body' => ['required', 'string'],
+            'thumbnail' => ['nullable', 'image', 'max:2048'],
+            'is_featured' => ['sometimes', 'boolean'],
+            'allow_comments' => ['sometimes', 'boolean'],
+            'is_indexable' => ['sometimes', 'boolean'],
+            'meta_title' => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string'],
+            'meta_keywords' => ['nullable', 'string'],
+        ]);
+
+        if (!empty($data['post_subcategory_id'])) {
+            $subcategory = PostSubcategory::query()
+                ->where('id', $data['post_subcategory_id'])
+                ->where('post_category_id', $data['post_category_id'])
+                ->first();
+
+            if (!$subcategory) {
+                throw ValidationException::withMessages([
+                    'post_subcategory_id' => 'The selected sub category does not belong to the chosen category.',
+                ]);
+            }
+        }
+
+        $data['is_featured'] = $request->boolean('is_featured');
+        $data['allow_comments'] = $request->boolean('allow_comments');
+        $data['is_indexable'] = $request->boolean('is_indexable');
+
+        $data['slug'] = $this->prepareSlug($data['slug'] ?? null, $data['title'], $postId);
+
+        return $data;
+    }
+
+    protected function prepareSlug(?string $slug, string $title, ?int $ignoreId = null): string
+    {
+        if (!empty($slug)) {
+            $slug = Str::slug($slug);
+            return Post::generateUniqueSlug($slug, $ignoreId);
+        }
+
+        return Post::generateUniqueSlug($title, $ignoreId);
+    }
+}

--- a/app/Http/Controllers/PostSubcategoryController.php
+++ b/app/Http/Controllers/PostSubcategoryController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PostCategory;
+use App\Models\PostSubcategory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class PostSubcategoryController extends Controller
+{
+    public function index(): View
+    {
+        $subcategories = PostSubcategory::with('category')
+            ->orderBy('name')
+            ->paginate(15);
+
+        return view('back.pages.post-subcategories.index', compact('subcategories'));
+    }
+
+    public function create(): View
+    {
+        $categories = PostCategory::orderBy('name')->get();
+
+        return view('back.pages.post-subcategories.create', compact('categories'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $this->validateSubcategory($request);
+
+        PostSubcategory::create($data);
+
+        return redirect()
+            ->route('admin.post-subcategories.index')
+            ->with('success', 'Sub category created successfully.');
+    }
+
+    public function edit(PostSubcategory $postSubcategory): View
+    {
+        $categories = PostCategory::orderBy('name')->get();
+
+        return view('back.pages.post-subcategories.edit', compact('postSubcategory', 'categories'));
+    }
+
+    public function update(Request $request, PostSubcategory $postSubcategory): RedirectResponse
+    {
+        $data = $this->validateSubcategory($request, $postSubcategory);
+
+        $postSubcategory->update($data);
+
+        return redirect()
+            ->route('admin.post-subcategories.edit', $postSubcategory)
+            ->with('success', 'Sub category updated successfully.');
+    }
+
+    public function destroy(PostSubcategory $postSubcategory): RedirectResponse
+    {
+        $postSubcategory->delete();
+
+        return redirect()
+            ->route('admin.post-subcategories.index')
+            ->with('success', 'Sub category deleted successfully.');
+    }
+
+    protected function validateSubcategory(Request $request, ?PostSubcategory $subcategory = null): array
+    {
+        $subcategoryId = $subcategory?->id;
+
+        $data = $request->validate([
+            'post_category_id' => ['required', Rule::exists('post_categories', 'id')],
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', Rule::unique('post_subcategories', 'slug')->ignore($subcategoryId)],
+            'description' => ['nullable', 'string'],
+        ]);
+
+        $data['slug'] = $this->prepareSlug($data['slug'] ?? null, $data['name'], $subcategoryId);
+
+        return $data;
+    }
+
+    protected function prepareSlug(?string $slug, string $name, ?int $ignoreId = null): string
+    {
+        if (!empty($slug)) {
+            $slug = Str::slug($slug);
+            return PostSubcategory::generateUniqueSlug($slug, $ignoreId);
+        }
+
+        return PostSubcategory::generateUniqueSlug($name, $ignoreId);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class Post extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'post_category_id',
+        'post_subcategory_id',
+        'title',
+        'slug',
+        'excerpt',
+        'body',
+        'thumbnail_path',
+        'is_featured',
+        'allow_comments',
+        'is_indexable',
+        'meta_title',
+        'meta_description',
+        'meta_keywords',
+    ];
+
+    protected $casts = [
+        'is_featured' => 'boolean',
+        'allow_comments' => 'boolean',
+        'is_indexable' => 'boolean',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Post $post) {
+            if (empty($post->slug)) {
+                $post->slug = static::generateUniqueSlug($post->title);
+            }
+        });
+
+        static::updating(function (Post $post) {
+            if ($post->isDirty('title') && !$post->isDirty('slug')) {
+                $post->slug = static::generateUniqueSlug($post->title, $post->id);
+            }
+        });
+    }
+
+    public static function generateUniqueSlug(string $title, ?int $ignoreId = null): string
+    {
+        $baseSlug = Str::slug($title);
+        $slug = $baseSlug;
+        $counter = 2;
+
+        while (static::query()
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $baseSlug.'-'.$counter++;
+        }
+
+        return $slug;
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(PostCategory::class, 'post_category_id');
+    }
+
+    public function subcategory()
+    {
+        return $this->belongsTo(PostSubcategory::class, 'post_subcategory_id');
+    }
+}

--- a/app/Models/PostCategory.php
+++ b/app/Models/PostCategory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class PostCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (PostCategory $category) {
+            if (empty($category->slug)) {
+                $category->slug = static::generateUniqueSlug($category->name);
+            }
+        });
+
+        static::updating(function (PostCategory $category) {
+            if ($category->isDirty('name') && !$category->isDirty('slug')) {
+                $category->slug = static::generateUniqueSlug($category->name, $category->id);
+            }
+        });
+    }
+
+    public static function generateUniqueSlug(string $name, ?int $ignoreId = null): string
+    {
+        $baseSlug = Str::slug($name);
+        $slug = $baseSlug;
+        $counter = 2;
+
+        while (static::query()
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $baseSlug.'-'.$counter++;
+        }
+
+        return $slug;
+    }
+
+    public function subcategories()
+    {
+        return $this->hasMany(PostSubcategory::class);
+    }
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/app/Models/PostSubcategory.php
+++ b/app/Models/PostSubcategory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class PostSubcategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'post_category_id',
+        'name',
+        'slug',
+        'description',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (PostSubcategory $subcategory) {
+            if (empty($subcategory->slug)) {
+                $subcategory->slug = static::generateUniqueSlug($subcategory->name);
+            }
+        });
+
+        static::updating(function (PostSubcategory $subcategory) {
+            if ($subcategory->isDirty('name') && !$subcategory->isDirty('slug')) {
+                $subcategory->slug = static::generateUniqueSlug($subcategory->name, $subcategory->id);
+            }
+        });
+    }
+
+    public static function generateUniqueSlug(string $name, ?int $ignoreId = null): string
+    {
+        $baseSlug = Str::slug($name);
+        $slug = $baseSlug;
+        $counter = 2;
+
+        while (static::query()
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = $baseSlug.'-'.$counter++;
+        }
+
+        return $slug;
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(PostCategory::class, 'post_category_id');
+    }
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/database/migrations/2025_09_29_000000_create_post_categories_table.php
+++ b/database/migrations/2025_09_29_000000_create_post_categories_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_categories');
+    }
+};

--- a/database/migrations/2025_09_29_000100_create_post_subcategories_table.php
+++ b/database/migrations/2025_09_29_000100_create_post_subcategories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('post_subcategories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_category_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('post_subcategories');
+    }
+};

--- a/database/migrations/2025_09_29_000200_create_posts_table.php
+++ b/database/migrations/2025_09_29_000200_create_posts_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_category_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('post_subcategory_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->string('excerpt', 500)->nullable();
+            $table->longText('body');
+            $table->string('thumbnail_path')->nullable();
+            $table->boolean('is_featured')->default(false);
+            $table->boolean('allow_comments')->default(true);
+            $table->boolean('is_indexable')->default(true);
+            $table->string('meta_title')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->text('meta_keywords')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/resources/views/back/layout/pages-layout.blade.php
+++ b/resources/views/back/layout/pages-layout.blade.php
@@ -440,6 +440,24 @@
                             </ul><!-- /child menu -->
                         </li><!-- /.menu-item -->
                         <!-- .menu-item -->
+                        <li class="menu-item has-child {{ request()->routeIs('admin.posts.*') || request()->routeIs('admin.post-categories.*') || request()->routeIs('admin.post-subcategories.*') ? 'has-active' : '' }}">
+                            <a href="#" class="menu-link"><span class="menu-icon oi oi-document"></span> <span class="menu-text">পোস্ট</span></a>
+                            <ul class="menu">
+                                <li class="menu-item {{ request()->routeIs('admin.posts.index') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.posts.index') }}" class="menu-link">সব পোস্ট</a>
+                                </li>
+                                <li class="menu-item {{ request()->routeIs('admin.posts.create') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.posts.create') }}" class="menu-link">নতুন পোস্ট</a>
+                                </li>
+                                <li class="menu-item {{ request()->routeIs('admin.post-categories.*') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.post-categories.index') }}" class="menu-link">ক্যাটাগরি</a>
+                                </li>
+                                <li class="menu-item {{ request()->routeIs('admin.post-subcategories.*') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.post-subcategories.index') }}" class="menu-link">সাব-ক্যাটাগরি</a>
+                                </li>
+                            </ul><!-- /child menu -->
+                        </li><!-- /.menu-item -->
+                        <!-- .menu-item -->
                         <li class="menu-item has-child {{ request()->routeIs('admin.settings*') ? 'has-active' : '' }}">
                             <a href="#" class="menu-link"><span class="menu-icon oi oi-wrench"></span> <span class="menu-text">Setting</span></a> <!-- child menu -->
                             <ul class="menu">

--- a/resources/views/back/pages/post-categories/_form.blade.php
+++ b/resources/views/back/pages/post-categories/_form.blade.php
@@ -1,0 +1,26 @@
+<div class="card">
+    <div class="card-body">
+        <div class="form-group">
+            <label for="name">ক্যাটাগরি নাম <span class="text-danger">*</span></label>
+            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $postCategory->name ?? '') }}" required>
+            @error('name')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group">
+            <label for="slug">স্লাগ</label>
+            <input type="text" class="form-control @error('slug') is-invalid @enderror" id="slug" name="slug" value="{{ old('slug', $postCategory->slug ?? '') }}" placeholder="category-slug">
+            <small class="form-text text-muted">শিরোনাম থেকে স্বয়ংক্রিয়ভাবে তৈরি হবে।</small>
+            @error('slug')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group mb-0">
+            <label for="description">বিবরণ</label>
+            <textarea class="form-control @error('description') is-invalid @enderror" id="description" name="description" rows="3" placeholder="ক্যাটাগরির সংক্ষিপ্ত বিবরণ">{{ old('description', $postCategory->description ?? '') }}</textarea>
+            @error('description')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+    </div>
+</div>

--- a/resources/views/back/pages/post-categories/create.blade.php
+++ b/resources/views/back/pages/post-categories/create.blade.php
@@ -1,0 +1,59 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'নতুন ক্যাটাগরি')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">নতুন ক্যাটাগরি</h1>
+                <p class="text-muted mb-0">পোস্ট গুলো সাজানোর জন্য একটি নতুন ক্যাটাগরি যুক্ত করুন।</p>
+            </div>
+            <a href="{{ route('admin.post-categories.index') }}" class="btn btn-outline-secondary">সব ক্যাটাগরি</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <form action="{{ route('admin.post-categories.store') }}" method="POST">
+            @csrf
+            @php($postCategory = $postCategory ?? new \App\Models\PostCategory())
+            @include('back.pages.post-categories._form', ['postCategory' => $postCategory])
+            <div class="text-right mt-3">
+                <button type="submit" class="btn btn-primary">ক্যাটাগরি সংরক্ষণ করুন</button>
+            </div>
+        </form>
+    </div>
+@endsection
+
+@push('scripts')
+    <script>
+        const nameInput = document.getElementById('name');
+        const slugInput = document.getElementById('slug');
+        const initialSlug = slugInput.value.trim();
+        let slugTouched = initialSlug.length > 0;
+
+        function generateSlug(value) {
+            return value
+                .toString()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\u0980-\u09FF\s-]/g, '')
+                .replace(/[\s_-]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+        }
+
+        nameInput.addEventListener('input', () => {
+            if (!slugTouched) {
+                slugInput.value = generateSlug(nameInput.value);
+            }
+        });
+
+        slugInput.addEventListener('input', () => {
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        slugInput.addEventListener('blur', () => {
+            slugInput.value = generateSlug(slugInput.value);
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+    </script>
+@endpush

--- a/resources/views/back/pages/post-categories/edit.blade.php
+++ b/resources/views/back/pages/post-categories/edit.blade.php
@@ -1,0 +1,74 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'ক্যাটাগরি সম্পাদনা')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">ক্যাটাগরি সম্পাদনা</h1>
+                <p class="text-muted mb-0">ক্যাটাগরির তথ্য পরিবর্তন করুন।</p>
+            </div>
+            <a href="{{ route('admin.post-categories.index') }}" class="btn btn-outline-secondary">সব ক্যাটাগরি</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
+        <form action="{{ route('admin.post-categories.update', $postCategory) }}" method="POST">
+            @csrf
+            @method('PUT')
+            @include('back.pages.post-categories._form', ['postCategory' => $postCategory])
+            <div class="d-flex justify-content-between mt-3">
+                <a href="{{ route('admin.post-categories.index') }}" class="btn btn-outline-secondary">বাতিল</a>
+                <button type="submit" class="btn btn-primary">পরিবর্তন সংরক্ষণ করুন</button>
+            </div>
+        </form>
+        <form action="{{ route('admin.post-categories.destroy', $postCategory) }}" method="POST" class="mt-3" onsubmit="return confirm('ক্যাটাগরি ডিলিট করবেন? এতে সংশ্লিষ্ট পোস্টও মুছে যেতে পারে।');">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-outline-danger">ক্যাটাগরি ডিলিট</button>
+        </form>
+    </div>
+@endsection
+
+@push('scripts')
+    <script>
+        const nameInput = document.getElementById('name');
+        const slugInput = document.getElementById('slug');
+        const initialSlug = slugInput.value.trim();
+        let slugTouched = initialSlug.length > 0;
+
+        function generateSlug(value) {
+            return value
+                .toString()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\u0980-\u09FF\s-]/g, '')
+                .replace(/[\s_-]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+        }
+
+        nameInput.addEventListener('input', () => {
+            if (!slugTouched) {
+                slugInput.value = generateSlug(nameInput.value);
+            }
+        });
+
+        slugInput.addEventListener('input', () => {
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        slugInput.addEventListener('blur', () => {
+            slugInput.value = generateSlug(slugInput.value);
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+    </script>
+@endpush

--- a/resources/views/back/pages/post-categories/index.blade.php
+++ b/resources/views/back/pages/post-categories/index.blade.php
@@ -1,0 +1,71 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'পোস্ট ক্যাটাগরি')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">ক্যাটাগরি ম্যানেজ করুন</h1>
+                <p class="text-muted mb-0">নতুন ক্যাটাগরি তৈরি ও পুরোনো ক্যাটাগরি আপডেট করুন।</p>
+            </div>
+            <a href="{{ route('admin.post-categories.create') }}" class="btn btn-primary">নতুন ক্যাটাগরি</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
+        <div class="card">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-striped mb-0">
+                        <thead>
+                            <tr>
+                                <th>নাম</th>
+                                <th>স্লাগ</th>
+                                <th>পোস্ট সংখ্যা</th>
+                                <th>সাব-ক্যাটাগরি</th>
+                                <th class="text-right">অ্যাকশন</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($categories as $category)
+                                <tr>
+                                    <td>
+                                        <strong>{{ $category->name }}</strong>
+                                    </td>
+                                    <td>{{ $category->slug }}</td>
+                                    <td>{{ $category->posts_count }}</td>
+                                    <td>{{ $category->subcategories_count }}</td>
+                                    <td class="text-right">
+                                        <a href="{{ route('admin.post-categories.edit', $category) }}" class="btn btn-sm btn-outline-primary">এডিট</a>
+                                        <form action="{{ route('admin.post-categories.destroy', $category) }}" method="POST" class="d-inline-block" onsubmit="return confirm('ক্যাটাগরি মুছে ফেলবেন?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">ডিলিট</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="text-center py-4 text-muted">কোন ক্যাটাগরি পাওয়া যায়নি।</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @if($categories->hasPages())
+                <div class="card-footer d-flex justify-content-end">
+                    {{ $categories->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/post-subcategories/_form.blade.php
+++ b/resources/views/back/pages/post-subcategories/_form.blade.php
@@ -1,0 +1,38 @@
+<div class="card">
+    <div class="card-body">
+        <div class="form-group">
+            <label for="post_category_id">মূল ক্যাটাগরি <span class="text-danger">*</span></label>
+            <select name="post_category_id" id="post_category_id" class="form-control @error('post_category_id') is-invalid @enderror" required>
+                <option value="">-- মূল ক্যাটাগরি নির্বাচন করুন --</option>
+                @foreach($categories as $category)
+                    <option value="{{ $category->id }}" @selected(old('post_category_id', $postSubcategory->post_category_id ?? '') == $category->id)>{{ $category->name }}</option>
+                @endforeach
+            </select>
+            @error('post_category_id')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group">
+            <label for="name">সাব-ক্যাটাগরি নাম <span class="text-danger">*</span></label>
+            <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $postSubcategory->name ?? '') }}" required>
+            @error('name')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group">
+            <label for="slug">স্লাগ</label>
+            <input type="text" class="form-control @error('slug') is-invalid @enderror" id="slug" name="slug" value="{{ old('slug', $postSubcategory->slug ?? '') }}" placeholder="subcategory-slug">
+            <small class="form-text text-muted">শিরোনাম থেকে স্বয়ংক্রিয়ভাবে তৈরি হবে।</small>
+            @error('slug')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group mb-0">
+            <label for="description">বিবরণ</label>
+            <textarea class="form-control @error('description') is-invalid @enderror" id="description" name="description" rows="3" placeholder="সাব-ক্যাটাগরির ব্যাখ্যা">{{ old('description', $postSubcategory->description ?? '') }}</textarea>
+            @error('description')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+    </div>
+</div>

--- a/resources/views/back/pages/post-subcategories/create.blade.php
+++ b/resources/views/back/pages/post-subcategories/create.blade.php
@@ -1,0 +1,59 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'নতুন সাব-ক্যাটাগরি')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">নতুন সাব-ক্যাটাগরি</h1>
+                <p class="text-muted mb-0">মূল ক্যাটাগরির অধীনে সাব-ক্যাটাগরি যুক্ত করুন।</p>
+            </div>
+            <a href="{{ route('admin.post-subcategories.index') }}" class="btn btn-outline-secondary">সব সাব-ক্যাটাগরি</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <form action="{{ route('admin.post-subcategories.store') }}" method="POST">
+            @csrf
+            @php($postSubcategory = $postSubcategory ?? new \App\Models\PostSubcategory())
+            @include('back.pages.post-subcategories._form', ['postSubcategory' => $postSubcategory, 'categories' => $categories])
+            <div class="text-right mt-3">
+                <button type="submit" class="btn btn-primary">সাব-ক্যাটাগরি সংরক্ষণ করুন</button>
+            </div>
+        </form>
+    </div>
+@endsection
+
+@push('scripts')
+    <script>
+        const nameInput = document.getElementById('name');
+        const slugInput = document.getElementById('slug');
+        const initialSlug = slugInput.value.trim();
+        let slugTouched = initialSlug.length > 0;
+
+        function generateSlug(value) {
+            return value
+                .toString()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\u0980-\u09FF\s-]/g, '')
+                .replace(/[\s_-]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+        }
+
+        nameInput.addEventListener('input', () => {
+            if (!slugTouched) {
+                slugInput.value = generateSlug(nameInput.value);
+            }
+        });
+
+        slugInput.addEventListener('input', () => {
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        slugInput.addEventListener('blur', () => {
+            slugInput.value = generateSlug(slugInput.value);
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+    </script>
+@endpush

--- a/resources/views/back/pages/post-subcategories/edit.blade.php
+++ b/resources/views/back/pages/post-subcategories/edit.blade.php
@@ -1,0 +1,74 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'সাব-ক্যাটাগরি সম্পাদনা')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">সাব-ক্যাটাগরি সম্পাদনা</h1>
+                <p class="text-muted mb-0">সাব-ক্যাটাগরির তথ্য আপডেট করুন।</p>
+            </div>
+            <a href="{{ route('admin.post-subcategories.index') }}" class="btn btn-outline-secondary">সব সাব-ক্যাটাগরি</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
+        <form action="{{ route('admin.post-subcategories.update', $postSubcategory) }}" method="POST">
+            @csrf
+            @method('PUT')
+            @include('back.pages.post-subcategories._form', ['postSubcategory' => $postSubcategory, 'categories' => $categories])
+            <div class="d-flex justify-content-between mt-3">
+                <a href="{{ route('admin.post-subcategories.index') }}" class="btn btn-outline-secondary">বাতিল</a>
+                <button type="submit" class="btn btn-primary">পরিবর্তন সংরক্ষণ করুন</button>
+            </div>
+        </form>
+        <form action="{{ route('admin.post-subcategories.destroy', $postSubcategory) }}" method="POST" class="mt-3" onsubmit="return confirm('সাব-ক্যাটাগরি ডিলিট করবেন?');">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-outline-danger">সাব-ক্যাটাগরি ডিলিট</button>
+        </form>
+    </div>
+@endsection
+
+@push('scripts')
+    <script>
+        const nameInput = document.getElementById('name');
+        const slugInput = document.getElementById('slug');
+        const initialSlug = slugInput.value.trim();
+        let slugTouched = initialSlug.length > 0;
+
+        function generateSlug(value) {
+            return value
+                .toString()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\u0980-\u09FF\s-]/g, '')
+                .replace(/[\s_-]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+        }
+
+        nameInput.addEventListener('input', () => {
+            if (!slugTouched) {
+                slugInput.value = generateSlug(nameInput.value);
+            }
+        });
+
+        slugInput.addEventListener('input', () => {
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        slugInput.addEventListener('blur', () => {
+            slugInput.value = generateSlug(slugInput.value);
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+    </script>
+@endpush

--- a/resources/views/back/pages/post-subcategories/index.blade.php
+++ b/resources/views/back/pages/post-subcategories/index.blade.php
@@ -1,0 +1,67 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'পোস্ট সাব-ক্যাটাগরি')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">সাব-ক্যাটাগরি ম্যানেজ করুন</h1>
+                <p class="text-muted mb-0">পোস্ট সাজাতে সাব-ক্যাটাগরি ব্যবহার করুন।</p>
+            </div>
+            <a href="{{ route('admin.post-subcategories.create') }}" class="btn btn-primary">নতুন সাব-ক্যাটাগরি</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
+        <div class="card">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-striped mb-0">
+                        <thead>
+                            <tr>
+                                <th>নাম</th>
+                                <th>মূল ক্যাটাগরি</th>
+                                <th>স্লাগ</th>
+                                <th class="text-right">অ্যাকশন</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($subcategories as $subcategory)
+                                <tr>
+                                    <td><strong>{{ $subcategory->name }}</strong></td>
+                                    <td>{{ $subcategory->category->name ?? '-' }}</td>
+                                    <td>{{ $subcategory->slug }}</td>
+                                    <td class="text-right">
+                                        <a href="{{ route('admin.post-subcategories.edit', $subcategory) }}" class="btn btn-sm btn-outline-primary">এডিট</a>
+                                        <form action="{{ route('admin.post-subcategories.destroy', $subcategory) }}" method="POST" class="d-inline-block" onsubmit="return confirm('সাব-ক্যাটাগরি মুছে ফেলবেন?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">ডিলিট</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center py-4 text-muted">কোন সাব-ক্যাটাগরি পাওয়া যায়নি।</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @if($subcategories->hasPages())
+                <div class="card-footer d-flex justify-content-end">
+                    {{ $subcategories->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/back/pages/posts/_form.blade.php
+++ b/resources/views/back/pages/posts/_form.blade.php
@@ -1,0 +1,131 @@
+@php
+    use Illuminate\Support\Facades\Storage;
+
+    $selectedCategory = old('post_category_id', $post->post_category_id ?? '');
+    $selectedSubcategory = old('post_subcategory_id', $post->post_subcategory_id ?? '');
+@endphp
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="form-group">
+            <label for="title">পোস্ট শিরোনাম <span class="text-danger">*</span></label>
+            <input type="text" name="title" id="title" class="form-control @error('title') is-invalid @enderror" value="{{ old('title', $post->title ?? '') }}" required>
+            @error('title')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group">
+            <label for="slug">স্লাগ</label>
+            <input type="text" name="slug" id="slug" class="form-control @error('slug') is-invalid @enderror" value="{{ old('slug', $post->slug ?? '') }}" placeholder="automatic-slug">
+            <small class="form-text text-muted">শিরোনাম অনুযায়ী স্বয়ংক্রিয়ভাবে তৈরি হবে, তবে চাইলে পরিবর্তন করতে পারেন।</small>
+            @error('slug')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                <label for="post_category_id">পোস্ট ক্যাটাগরি <span class="text-danger">*</span></label>
+                <select name="post_category_id" id="post_category_id" class="form-control @error('post_category_id') is-invalid @enderror" required>
+                    <option value="">-- ক্যাটাগরি নির্বাচন করুন --</option>
+                    @foreach($categories as $category)
+                        <option value="{{ $category->id }}" @selected($category->id == $selectedCategory)>{{ $category->name }}</option>
+                    @endforeach
+                </select>
+                @error('post_category_id')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+            <div class="form-group col-md-6">
+                <label for="post_subcategory_id">সাব-ক্যাটাগরি</label>
+                <select name="post_subcategory_id" id="post_subcategory_id" class="form-control @error('post_subcategory_id') is-invalid @enderror">
+                    <option value="">-- সাব-ক্যাটাগরি নির্বাচন করুন --</option>
+                    @foreach($categories as $category)
+                        @foreach($category->subcategories as $subcategory)
+                            <option value="{{ $subcategory->id }}" data-parent="{{ $category->id }}" @selected($subcategory->id == $selectedSubcategory)>{{ $subcategory->name }}</option>
+                        @endforeach
+                    @endforeach
+                </select>
+                @error('post_subcategory_id')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="excerpt">সংক্ষিপ্ত বিবরণ</label>
+            <textarea name="excerpt" id="excerpt" rows="3" class="form-control @error('excerpt') is-invalid @enderror" placeholder="পোস্টের ছোট্ট সারসংক্ষেপ লিখুন">{{ old('excerpt', $post->excerpt ?? '') }}</textarea>
+            @error('excerpt')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group">
+            <label for="body">পোস্ট বর্ণনা <span class="text-danger">*</span></label>
+            <textarea name="body" id="body" rows="10" class="form-control @error('body') is-invalid @enderror" required>{{ old('body', $post->body ?? '') }}</textarea>
+            @error('body')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">মিডিয়া</div>
+    <div class="card-body">
+        <div class="form-group">
+            <label for="thumbnail">ফিচারড ইমেজ</label>
+            <input type="file" name="thumbnail" id="thumbnail" class="form-control-file @error('thumbnail') is-invalid @enderror" accept="image/*">
+            @error('thumbnail')
+                <div class="text-danger small">{{ $message }}</div>
+            @enderror
+            @if(!empty($post->thumbnail_path))
+                <div class="mt-3">
+                    <p class="mb-1">বর্তমান ইমেজ:</p>
+                    <img src="{{ Storage::disk('public')->exists($post->thumbnail_path ?? '') ? Storage::url($post->thumbnail_path) : asset($post->thumbnail_path) }}" alt="Thumbnail" class="img-thumbnail" style="max-height: 150px;">
+                </div>
+            @endif
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">অপশন</div>
+    <div class="card-body">
+        <div class="custom-control custom-switch mb-2">
+            <input type="checkbox" class="custom-control-input" id="is_featured" name="is_featured" value="1" @checked(old('is_featured', $post->is_featured ?? false))>
+            <label class="custom-control-label" for="is_featured">ফিচারড পোস্ট হিসেবে চিহ্নিত করুন</label>
+        </div>
+        <div class="custom-control custom-switch mb-2">
+            <input type="checkbox" class="custom-control-input" id="allow_comments" name="allow_comments" value="1" @checked(old('allow_comments', ($post->allow_comments ?? true)))>
+            <label class="custom-control-label" for="allow_comments">মন্তব্য করার অনুমতি দিন</label>
+        </div>
+        <div class="custom-control custom-switch">
+            <input type="checkbox" class="custom-control-input" id="is_indexable" name="is_indexable" value="1" @checked(old('is_indexable', ($post->is_indexable ?? true)))>
+            <label class="custom-control-label" for="is_indexable">সার্চ ইঞ্জিনে ইনডেক্স করুন</label>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">মেটা তথ্য</div>
+    <div class="card-body">
+        <div class="form-group">
+            <label for="meta_title">মেটা টাইটেল</label>
+            <input type="text" name="meta_title" id="meta_title" class="form-control @error('meta_title') is-invalid @enderror" value="{{ old('meta_title', $post->meta_title ?? '') }}" placeholder="SEO টাইটেল">
+            @error('meta_title')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group">
+            <label for="meta_description">মেটা বর্ণনা</label>
+            <textarea name="meta_description" id="meta_description" rows="3" class="form-control @error('meta_description') is-invalid @enderror" placeholder="SEO বর্ণনা">{{ old('meta_description', $post->meta_description ?? '') }}</textarea>
+            @error('meta_description')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="form-group mb-0">
+            <label for="meta_keywords">মেটা কীওয়ার্ড</label>
+            <input type="text" name="meta_keywords" id="meta_keywords" class="form-control @error('meta_keywords') is-invalid @enderror" value="{{ old('meta_keywords', $post->meta_keywords ?? '') }}" placeholder="কমা (,) দিয়ে আলাদা করুন">
+            @error('meta_keywords')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+    </div>
+</div>

--- a/resources/views/back/pages/posts/create.blade.php
+++ b/resources/views/back/pages/posts/create.blade.php
@@ -1,0 +1,96 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'নতুন পোস্ট যুক্ত করুন')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">নতুন পোস্ট</h1>
+                <p class="text-muted mb-0">সব তথ্য পূরণ করে একটি নতুন পোস্ট তৈরি করুন।</p>
+            </div>
+            <a href="{{ route('admin.posts.index') }}" class="btn btn-outline-secondary">সব পোস্ট দেখুন</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <form action="{{ route('admin.posts.store') }}" method="POST" enctype="multipart/form-data">
+            @csrf
+            @php($post = $post ?? new \App\Models\Post())
+            @include('back.pages.posts._form', ['post' => $post, 'categories' => $categories])
+            <div class="text-right">
+                <button type="submit" class="btn btn-primary">পোস্ট সংরক্ষণ করুন</button>
+            </div>
+        </form>
+    </div>
+@endsection
+
+@push('scripts')
+    <script src="https://cdn.ckeditor.com/4.22.1/standard/ckeditor.js"></script>
+    <script>
+        CKEDITOR.replace('body', {
+            height: 320,
+            removeButtons: 'Save,NewPage,Preview,Print,Templates'
+        });
+
+        const titleInput = document.getElementById('title');
+        const slugInput = document.getElementById('slug');
+        const categorySelect = document.getElementById('post_category_id');
+        const subcategorySelect = document.getElementById('post_subcategory_id');
+        const initialSlug = slugInput.value.trim();
+        let slugTouched = initialSlug.length > 0;
+
+        function generateSlug(value) {
+            return value
+                .toString()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\u0980-\u09FF\s-]/g, '')
+                .replace(/[\s_-]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+        }
+
+        function filterSubcategories() {
+            const categoryId = categorySelect.value;
+            let hasVisible = false;
+
+            Array.from(subcategorySelect.options).forEach(option => {
+                if (!option.value) {
+                    return;
+                }
+
+                const matches = !categoryId || option.dataset.parent === categoryId;
+                option.hidden = !matches;
+
+                if (!matches && option.selected) {
+                    option.selected = false;
+                }
+
+                if (matches) {
+                    hasVisible = true;
+                }
+            });
+
+            if (!hasVisible) {
+                subcategorySelect.value = '';
+            }
+        }
+
+        titleInput.addEventListener('input', () => {
+            if (!slugTouched) {
+                slugInput.value = generateSlug(titleInput.value);
+            }
+        });
+
+        slugInput.addEventListener('input', () => {
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        slugInput.addEventListener('blur', () => {
+            slugInput.value = generateSlug(slugInput.value);
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        categorySelect.addEventListener('change', filterSubcategories);
+        filterSubcategories();
+    </script>
+@endpush

--- a/resources/views/back/pages/posts/edit.blade.php
+++ b/resources/views/back/pages/posts/edit.blade.php
@@ -1,0 +1,102 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'পোস্ট সম্পাদনা')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">পোস্ট সম্পাদনা</h1>
+                <p class="text-muted mb-0">পোস্টের তথ্য আপডেট করুন।</p>
+            </div>
+            <a href="{{ route('admin.posts.index') }}" class="btn btn-outline-secondary">সব পোস্ট</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
+        <form action="{{ route('admin.posts.update', $post) }}" method="POST" enctype="multipart/form-data">
+            @csrf
+            @method('PUT')
+            @include('back.pages.posts._form', ['post' => $post, 'categories' => $categories])
+            <div class="d-flex justify-content-between">
+                <a href="{{ route('admin.posts.index') }}" class="btn btn-outline-secondary">বাতিল</a>
+                <button type="submit" class="btn btn-primary">পরিবর্তন সংরক্ষণ করুন</button>
+            </div>
+        </form>
+        <form action="{{ route('admin.posts.destroy', $post) }}" method="POST" class="mt-3" onsubmit="return confirm('পোস্টটি সম্পূর্ণ মুছে ফেলতে চান?');">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-outline-danger">পোস্ট ডিলিট</button>
+        </form>
+    </div>
+@endsection
+
+@push('scripts')
+    <script src="https://cdn.ckeditor.com/4.22.1/standard/ckeditor.js"></script>
+    <script>
+        CKEDITOR.replace('body', {
+            height: 320,
+            removeButtons: 'Save,NewPage,Preview,Print,Templates'
+        });
+
+        const titleInput = document.getElementById('title');
+        const slugInput = document.getElementById('slug');
+        const categorySelect = document.getElementById('post_category_id');
+        const subcategorySelect = document.getElementById('post_subcategory_id');
+        const initialSlug = slugInput.value.trim();
+        let slugTouched = initialSlug.length > 0;
+
+        function generateSlug(value) {
+            return value
+                .toString()
+                .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\u0980-\u09FF\s-]/g, '')
+                .replace(/[\s_-]+/g, '-')
+                .replace(/^-+|-+$/g, '');
+        }
+
+        function filterSubcategories() {
+            const categoryId = categorySelect.value;
+
+            Array.from(subcategorySelect.options).forEach(option => {
+                if (!option.value) {
+                    return;
+                }
+
+                const matches = !categoryId || option.dataset.parent === categoryId;
+                option.hidden = !matches;
+
+                if (!matches && option.selected) {
+                    option.selected = false;
+                }
+            });
+        }
+
+        titleInput.addEventListener('input', () => {
+            if (!slugTouched) {
+                slugInput.value = generateSlug(titleInput.value);
+            }
+        });
+
+        slugInput.addEventListener('input', () => {
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        slugInput.addEventListener('blur', () => {
+            slugInput.value = generateSlug(slugInput.value);
+            slugTouched = slugInput.value.trim().length > 0;
+        });
+
+        categorySelect.addEventListener('change', filterSubcategories);
+        filterSubcategories();
+    </script>
+@endpush

--- a/resources/views/back/pages/posts/index.blade.php
+++ b/resources/views/back/pages/posts/index.blade.php
@@ -1,0 +1,88 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', 'সব পোস্ট')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="page-title">সব পোস্ট</h1>
+                <p class="text-muted mb-0">আপনার সব আর্টিকেল এখানে ম্যানেজ করতে পারেন।</p>
+            </div>
+            <a href="{{ route('admin.posts.create') }}" class="btn btn-primary">নতুন পোস্ট</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
+        <div class="card">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-striped mb-0">
+                        <thead>
+                            <tr>
+                                <th style="width: 45%">শিরোনাম</th>
+                                <th>ক্যাটাগরি</th>
+                                <th>সাব-ক্যাটাগরি</th>
+                                <th>ফিচারড</th>
+                                <th>ইনডেক্স</th>
+                                <th>আপডেট</th>
+                                <th class="text-right">অ্যাকশন</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($posts as $post)
+                                <tr>
+                                    <td>
+                                        <strong>{{ $post->title }}</strong>
+                                        <div class="small text-muted">/{{ $post->slug }}</div>
+                                    </td>
+                                    <td>{{ $post->category->name ?? 'N/A' }}</td>
+                                    <td>{{ $post->subcategory->name ?? '-' }}</td>
+                                    <td>
+                                        @if($post->is_featured)
+                                            <span class="badge badge-success">হ্যাঁ</span>
+                                        @else
+                                            <span class="badge badge-light">না</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($post->is_indexable)
+                                            <span class="badge badge-info">Index</span>
+                                        @else
+                                            <span class="badge badge-secondary">Noindex</span>
+                                        @endif
+                                    </td>
+                                    <td>{{ $post->updated_at->format('d M, Y') }}</td>
+                                    <td class="text-right">
+                                        <a href="{{ route('admin.posts.edit', $post) }}" class="btn btn-sm btn-outline-primary">এডিট</a>
+                                        <form action="{{ route('admin.posts.destroy', $post) }}" method="POST" class="d-inline-block" onsubmit="return confirm('পোস্ট মুছে ফেলতে চান?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">ডিলিট</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="text-center py-4 text-muted">কোন পোস্ট পাওয়া যায়নি।</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @if($posts->hasPages())
+                <div class="card-footer d-flex justify-content-end">
+                    {{ $posts->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,9 @@ use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\PostCategoryController;
+use App\Http\Controllers\PostController;
+use App\Http\Controllers\PostSubcategoryController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -34,5 +37,9 @@ Route::prefix('admin')->name('admin.')->group(function () {
               Route::post('/update-profile', 'updateProfile')->name('update.profile');
               Route::get('/settings', 'generalSettings')->name('settings');
        });
+
+       Route::resource('posts', PostController::class);
+       Route::resource('post-categories', PostCategoryController::class)->except(['show']);
+       Route::resource('post-subcategories', PostSubcategoryController::class)->except(['show']);
     });
 });


### PR DESCRIPTION
## Summary
- add database tables and Eloquent models for post categories, subcategories, and posts with slug automation
- implement admin controllers and validation to manage posts, categories, and subcategories including thumbnail uploads and publishing options
- build Blade views with CKEditor 4, slug helpers, and updated navigation to manage the full post workflow from the dashboard

## Testing
- php -l app/Http/Controllers/PostController.php
- php -l app/Http/Controllers/PostCategoryController.php
- php -l app/Http/Controllers/PostSubcategoryController.php
- php -l app/Models/Post.php
- php -l app/Models/PostCategory.php
- php -l app/Models/PostSubcategory.php

------
https://chatgpt.com/codex/tasks/task_e_68d9a1f956508326918f99d713d399c5