### PR TITLE
Add Livewire-based post management with CKEditor support

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+
+class PostController extends Controller
+{
+    public function index()
+    {
+        return view('back.pages.posts.index', [
+            'pageTitle' => 'Posts',
+        ]);
+    }
+
+    public function create()
+    {
+        return view('back.pages.posts.create', [
+            'pageTitle' => 'Create Post',
+        ]);
+    }
+
+    public function edit(Post $post)
+    {
+        return view('back.pages.posts.edit', [
+            'pageTitle' => 'Edit Post',
+            'post' => $post,
+        ]);
+    }
+}

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Category;
+use App\Models\Post;
+use App\Models\SubCategory;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class PostForm extends Component
+{
+    use WithFileUploads;
+
+    public ?Post $post = null;
+
+    public string $title = '';
+    public string $slug = '';
+    public string $description = '';
+    public string $category_id = '';
+    public string $sub_category_id = '';
+    public bool $is_featured = false;
+    public bool $allow_comments = true;
+    public bool $is_indexable = true;
+    public ?string $meta_title = null;
+    public ?string $meta_description = null;
+    public ?string $meta_keywords = null;
+    public $thumbnail;
+    public ?string $existingThumbnail = null;
+
+    public bool $autoGenerateSlug = true;
+
+    protected ?string $lastSyncedDescription = null;
+
+    public function mount(?Post $post = null): void
+    {
+        $this->post = $post;
+
+        if ($post) {
+            $this->title = $post->title;
+            $this->slug = $post->slug;
+            $this->description = $post->description;
+            $this->category_id = (string) $post->category_id;
+            $this->sub_category_id = $post->sub_category_id ? (string) $post->sub_category_id : '';
+            $this->is_featured = $post->is_featured;
+            $this->allow_comments = $post->allow_comments;
+            $this->is_indexable = $post->is_indexable;
+            $this->meta_title = $post->meta_title;
+            $this->meta_description = $post->meta_description;
+            $this->meta_keywords = $post->meta_keywords;
+            $this->existingThumbnail = $post->thumbnail_path;
+            $this->autoGenerateSlug = false;
+        }
+
+        $this->lastSyncedDescription = $this->description;
+    }
+
+    public function updatedTitle($value): void
+    {
+        if ($this->autoGenerateSlug) {
+            $this->slug = $this->generateUniqueSlug($value);
+        }
+    }
+
+    public function updatedSlug($value): void
+    {
+        $this->autoGenerateSlug = false;
+        $this->slug = $this->generateUniqueSlug($value ?: $this->title);
+    }
+
+    public function updatedCategoryId($value): void
+    {
+        if ($value === null || $value === '') {
+            $this->sub_category_id = '';
+            return;
+        }
+
+        if ($this->sub_category_id) {
+            $isValid = SubCategory::where('id', $this->sub_category_id)
+                ->where('category_id', $value)
+                ->exists();
+
+            if (! $isValid) {
+                $this->sub_category_id = '';
+            }
+        }
+    }
+
+    public function removeExistingThumbnail(): void
+    {
+        if (! $this->existingThumbnail) {
+            return;
+        }
+
+        Storage::disk('public')->delete($this->existingThumbnail);
+        $this->existingThumbnail = null;
+
+        if ($this->post) {
+            $this->post->update(['thumbnail_path' => null]);
+        }
+
+        $this->dispatch('showToastr', type: 'success', message: 'Thumbnail removed successfully.');
+    }
+
+    public function save(): mixed
+    {
+        $data = $this->validate($this->rules());
+
+        if (blank($data['slug'])) {
+            $data['slug'] = $this->generateUniqueSlug($this->title);
+        }
+
+        if (! $this->category_id) {
+            $this->addError('category_id', 'Please select a category.');
+            return null;
+        }
+
+        $data['category_id'] = (int) $this->category_id;
+        $data['sub_category_id'] = $this->sub_category_id ? (int) $this->sub_category_id : null;
+
+        if ($data['sub_category_id']) {
+            $isValidSubCategory = SubCategory::where('id', $data['sub_category_id'])
+                ->where('category_id', $data['category_id'])
+                ->exists();
+
+            if (! $isValidSubCategory) {
+                $this->addError('sub_category_id', 'Selected sub category does not belong to the chosen category.');
+                return null;
+            }
+        }
+
+        $data['is_featured'] = $this->is_featured;
+        $data['allow_comments'] = $this->allow_comments;
+        $data['is_indexable'] = $this->is_indexable;
+        $data['description'] = $this->description;
+        $data['meta_title'] = $this->meta_title;
+        $data['meta_description'] = $this->meta_description;
+        $data['meta_keywords'] = $this->meta_keywords;
+
+        if ($this->thumbnail) {
+            if ($this->existingThumbnail) {
+                Storage::disk('public')->delete($this->existingThumbnail);
+            }
+
+            $data['thumbnail_path'] = $this->thumbnail->store('posts', 'public');
+        }
+
+        if ($this->post) {
+            $this->post->update($data);
+            $message = 'Post updated successfully.';
+        } else {
+            $this->post = Post::create($data);
+            $message = 'Post created successfully.';
+        }
+
+        $this->dispatch('showToastr', type: 'success', message: $message);
+
+        return redirect()->route('admin.posts.index')->with('success', $message);
+    }
+
+    protected function rules(): array
+    {
+        $postId = $this->post?->id;
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('posts', 'slug')->ignore($postId),
+            ],
+            'description' => ['required', 'string'],
+            'category_id' => ['nullable', 'integer', Rule::exists('categories', 'id')],
+            'sub_category_id' => ['nullable', 'integer', Rule::exists('sub_categories', 'id')],
+            'meta_title' => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string'],
+            'meta_keywords' => ['nullable', 'string'],
+            'thumbnail' => ['nullable', 'image', 'max:4096'],
+        ];
+    }
+
+    protected function generateUniqueSlug(?string $value): string
+    {
+        $base = Str::slug($value ?? '');
+
+        if ($base === '') {
+            return '';
+        }
+
+        $slug = $base;
+        $counter = 2;
+
+        while ($this->slugExists($slug)) {
+            $slug = $base.'-'.$counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+
+    protected function slugExists(string $slug): bool
+    {
+        return Post::when($this->post, fn ($query) => $query->where('id', '!=', $this->post->id))
+            ->where('slug', $slug)
+            ->exists();
+    }
+
+    #[Computed]
+    public function categories()
+    {
+        return Category::orderBy('name')->get();
+    }
+
+    #[Computed]
+    public function availableSubCategories()
+    {
+        if (! $this->category_id) {
+            return collect();
+        }
+
+        return SubCategory::where('category_id', $this->category_id)
+            ->orderBy('name')
+            ->get();
+    }
+
+    public function render()
+    {
+        if ($this->lastSyncedDescription !== $this->description) {
+            $this->dispatch('syncPostEditor', $this->description ?? '');
+            $this->lastSyncedDescription = $this->description;
+        }
+
+        return view('livewire.admin.post-form');
+    }
+}

--- a/app/Livewire/Admin/PostsTable.php
+++ b/app/Livewire/Admin/PostsTable.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Post;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class PostsTable extends Component
+{
+    use WithPagination;
+
+    protected $paginationTheme = 'bootstrap';
+
+    public string $search = '';
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggleFeatured(int $postId): void
+    {
+        $post = Post::findOrFail($postId);
+        $post->update(['is_featured' => ! $post->is_featured]);
+
+        $this->dispatch('showToastr', type: 'success', message: 'Post featured status updated.');
+    }
+
+    public function toggleComments(int $postId): void
+    {
+        $post = Post::findOrFail($postId);
+        $post->update(['allow_comments' => ! $post->allow_comments]);
+
+        $this->dispatch('showToastr', type: 'success', message: 'Comment setting updated.');
+    }
+
+    public function toggleIndexable(int $postId): void
+    {
+        $post = Post::findOrFail($postId);
+        $post->update(['is_indexable' => ! $post->is_indexable]);
+
+        $this->dispatch('showToastr', type: 'success', message: 'Indexing preference updated.');
+    }
+
+    public function deletePost(int $postId): void
+    {
+        $post = Post::findOrFail($postId);
+
+        if ($post->thumbnail_path) {
+            Storage::disk('public')->delete($post->thumbnail_path);
+        }
+
+        $post->delete();
+
+        $this->dispatch('showToastr', type: 'success', message: 'Post removed successfully.');
+
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $posts = Post::with(['category', 'subCategory'])
+            ->when($this->search, function ($query) {
+                $query->where(function ($nested) {
+                    $nested->where('title', 'like', '%'.$this->search.'%')
+                        ->orWhere('slug', 'like', '%'.$this->search.'%')
+                        ->orWhere('meta_title', 'like', '%'.$this->search.'%');
+                });
+            })
+            ->orderByDesc('created_at')
+            ->paginate(10);
+
+        return view('livewire.admin.posts-table', [
+            'posts' => $posts,
+        ]);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Post extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'category_id',
+        'sub_category_id',
+        'title',
+        'slug',
+        'thumbnail_path',
+        'description',
+        'is_featured',
+        'allow_comments',
+        'is_indexable',
+        'meta_title',
+        'meta_description',
+        'meta_keywords',
+    ];
+
+    protected $casts = [
+        'is_featured' => 'boolean',
+        'allow_comments' => 'boolean',
+        'is_indexable' => 'boolean',
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function subCategory(): BelongsTo
+    {
+        return $this->belongsTo(SubCategory::class);
+    }
+}

--- a/database/migrations/2025_09_29_000000_create_posts_table.php
+++ b/database/migrations/2025_09_29_000000_create_posts_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained()->cascadeOnUpdate()->restrictOnDelete();
+            $table->foreignId('sub_category_id')->nullable()->constrained('sub_categories')->cascadeOnUpdate()->nullOnDelete();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->string('thumbnail_path')->nullable();
+            $table->longText('description');
+            $table->boolean('is_featured')->default(false);
+            $table->boolean('allow_comments')->default(true);
+            $table->boolean('is_indexable')->default(true);
+            $table->string('meta_title')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->text('meta_keywords')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/resources/views/back/layout/pages-layout.blade.php
+++ b/resources/views/back/layout/pages-layout.blade.php
@@ -383,6 +383,9 @@
                         <li class="menu-item {{ request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
                             <a href="{{ route('admin.subcategories.index') }}" class="menu-link"><span class="menu-icon oi oi-layers"></span> <span class="menu-text">Sub Categories</span></a>
                         </li>
+                        <li class="menu-item {{ request()->routeIs('admin.posts.*') ? 'has-active' : '' }}">
+                            <a href="{{ route('admin.posts.index') }}" class="menu-link"><span class="menu-icon oi oi-document"></span> <span class="menu-text">Posts</span></a>
+                        </li>
                         <!-- .menu-item -->
                         <li class="menu-item has-child {{ request()->routeIs('admin.settings*') ? 'has-active' : '' }}">
                             <a href="#" class="menu-link"><span class="menu-icon oi oi-wrench"></span> <span class="menu-text">Setting</span></a> <!-- child menu -->

--- a/resources/views/back/pages/posts/create.blade.php
+++ b/resources/views/back/pages/posts/create.blade.php
@@ -1,0 +1,14 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Create Post')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <h1 class="page-title mb-0">Create Post</h1>
+            <a href="{{ route('admin.posts.index') }}" class="btn btn-link">&larr; Back to posts</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <livewire:admin.post-form />
+    </div>
+@endsection

--- a/resources/views/back/pages/posts/edit.blade.php
+++ b/resources/views/back/pages/posts/edit.blade.php
@@ -1,0 +1,14 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Edit Post')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <h1 class="page-title mb-0">Edit Post</h1>
+            <a href="{{ route('admin.posts.index') }}" class="btn btn-link">&larr; Back to posts</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <livewire:admin.post-form :post="$post" />
+    </div>
+@endsection

--- a/resources/views/back/pages/posts/index.blade.php
+++ b/resources/views/back/pages/posts/index.blade.php
@@ -1,0 +1,21 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Posts')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+            <div>
+                <h1 class="page-title">Posts</h1>
+                <p class="text-muted">Manage blog posts, featured options, and metadata.</p>
+            </div>
+            <a href="{{ route('admin.posts.create') }}" class="btn btn-primary">Create New Post</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+
+        <livewire:admin.posts-table />
+    </div>
+@endsection

--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -1,0 +1,202 @@
+<div>
+    <form wire:submit.prevent="save" class="card card-fluid">
+        <div class="card-body">
+            <div class="form-row">
+                <div class="form-group col-md-8">
+                    <label for="postTitle">Post Title <span class="text-danger">*</span></label>
+                    <input type="text" id="postTitle" class="form-control @error('title') is-invalid @enderror" wire:model.defer="title" placeholder="Enter post title">
+                    @error('title')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="form-group col-md-4">
+                    <label for="postSlug">Slug</label>
+                    <input type="text" id="postSlug" class="form-control @error('slug') is-invalid @enderror" wire:model.defer="slug" placeholder="Auto generated from title">
+                    @error('slug')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+
+            <div class="form-row">
+                <div class="form-group col-md-6">
+                    <label for="postCategory">Category <span class="text-danger">*</span></label>
+                    <select id="postCategory" class="form-control @error('category_id') is-invalid @enderror" wire:model="category_id">
+                        <option value="">Select category</option>
+                        @foreach ($this->categories as $category)
+                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('category_id')
+                        <div class="invalid-feedback d-block">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="form-group col-md-6">
+                    <label for="postSubCategory">Sub Category</label>
+                    <select id="postSubCategory" class="form-control @error('sub_category_id') is-invalid @enderror" wire:model="sub_category_id">
+                        <option value="">None</option>
+                        @foreach ($this->availableSubCategories as $subCategory)
+                            <option value="{{ $subCategory->id }}">{{ $subCategory->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('sub_category_id')
+                        <div class="invalid-feedback d-block">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+
+            <div class="form-group" wire:ignore>
+                <label for="postDescription">Post Description <span class="text-danger">*</span></label>
+                <textarea id="postDescription" class="form-control @error('description') is-invalid @enderror">{!! $description !!}</textarea>
+                @error('description')
+                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="form-row">
+                <div class="form-group col-md-6">
+                    <label for="thumbnail">Post Thumbnail</label>
+                    <input type="file" id="thumbnail" class="form-control-file @error('thumbnail') is-invalid @enderror" wire:model="thumbnail" accept="image/*">
+                    @error('thumbnail')
+                        <div class="invalid-feedback d-block">{{ $message }}</div>
+                    @enderror
+                    <div class="mt-3">
+                        @if ($thumbnail)
+                            <p class="text-muted small mb-2">Preview:</p>
+                            <img src="{{ $thumbnail->temporaryUrl() }}" alt="Thumbnail preview" class="img-thumbnail" style="max-height: 180px;">
+                        @elseif ($existingThumbnail)
+                            <p class="text-muted small mb-2">Current thumbnail:</p>
+                            <div class="d-flex align-items-center gap-3">
+                                <img src="{{ asset('storage/' . $existingThumbnail) }}" alt="Current thumbnail" class="img-thumbnail" style="max-height: 180px;">
+                                <button type="button" class="btn btn-sm btn-outline-danger" wire:click="removeExistingThumbnail">Remove</button>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+                <div class="form-group col-md-6">
+                    <label>Post Options</label>
+                    <div class="custom-control custom-switch">
+                        <input type="checkbox" class="custom-control-input" id="isFeatured" wire:model.defer="is_featured">
+                        <label class="custom-control-label" for="isFeatured">Mark as featured post</label>
+                    </div>
+                    <div class="custom-control custom-switch mt-2">
+                        <input type="checkbox" class="custom-control-input" id="allowComments" wire:model.defer="allow_comments">
+                        <label class="custom-control-label" for="allowComments">Allow comments on this post</label>
+                    </div>
+                    <div class="custom-control custom-switch mt-2">
+                        <input type="checkbox" class="custom-control-input" id="isIndexable" wire:model.defer="is_indexable">
+                        <label class="custom-control-label" for="isIndexable">Allow search engines to index</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card card-body border mt-4">
+                <h5 class="card-title">Meta Information</h5>
+                <div class="form-group">
+                    <label for="metaTitle">Meta Title</label>
+                    <input type="text" id="metaTitle" class="form-control @error('meta_title') is-invalid @enderror" wire:model.defer="meta_title" placeholder="Custom meta title">
+                    @error('meta_title')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="form-group">
+                    <label for="metaDescription">Meta Description</label>
+                    <textarea id="metaDescription" rows="3" class="form-control @error('meta_description') is-invalid @enderror" wire:model.defer="meta_description" placeholder="Short summary for search engines"></textarea>
+                    @error('meta_description')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="form-group">
+                    <label for="metaKeywords">Meta Keywords</label>
+                    <input type="text" id="metaKeywords" class="form-control @error('meta_keywords') is-invalid @enderror" wire:model.defer="meta_keywords" placeholder="Comma separated keywords">
+                    @error('meta_keywords')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-end">
+            <a href="{{ route('admin.posts.index') }}" class="btn btn-link">Cancel</a>
+            <button type="submit" class="btn btn-primary ml-2">
+                {{ $post ? 'Update Post' : 'Create Post' }}
+            </button>
+        </div>
+    </form>
+</div>
+
+@pushOnce('scripts')
+    <script src="https://cdn.ckeditor.com/4.22.1/standard/ckeditor.js"></script>
+    <script>
+        document.addEventListener('livewire:init', () => {
+            const initializeEditor = () => {
+                const textarea = document.getElementById('postDescription');
+                if (!textarea || textarea.dataset.initialized) {
+                    return;
+                }
+
+                textarea.dataset.initialized = 'true';
+
+                if (typeof CKEDITOR === 'undefined') {
+                    console.error('CKEditor 4 is not loaded.');
+                    return;
+                }
+
+                const componentId = textarea.closest('[wire\\:id]')?.getAttribute('wire:id');
+                if (!componentId) {
+                    return;
+                }
+
+                const editor = CKEDITOR.replace('postDescription', {
+                    height: 360,
+                    removePlugins: 'easyimage,cloudservices',
+                    extraAllowedContent: '*(*){*}',
+                });
+
+                editor.on('change', () => {
+                    const data = editor.getData();
+                    const component = Livewire.find(componentId);
+                    if (component) {
+                        component.set('description', data);
+                    }
+                });
+
+                Livewire.on('syncPostEditor', (content) => {
+                    if (editor.status !== 'ready') {
+                        editor.on('instanceReady', () => {
+                            if (editor.getData() !== content) {
+                                editor.setData(content || '');
+                            }
+                        });
+                        return;
+                    }
+
+                    if (editor.getData() !== content) {
+                        editor.setData(content || '');
+                    }
+                });
+
+                window.addEventListener('beforeunload', () => {
+                    if (editor && editor.status === 'ready') {
+                        editor.destroy();
+                    }
+                });
+            };
+
+            initializeEditor();
+
+            Livewire.hook('element.removed', ({ el }) => {
+                if (el && el.id === 'postDescription' && el.dataset.initialized) {
+                    const instance = CKEDITOR.instances.postDescription;
+                    if (instance) {
+                        instance.destroy();
+                    }
+                    delete el.dataset.initialized;
+                }
+            });
+
+            Livewire.hook('message.processed', () => {
+                initializeEditor();
+            });
+        });
+    </script>
+@endpushOnce

--- a/resources/views/livewire/admin/posts-table.blade.php
+++ b/resources/views/livewire/admin/posts-table.blade.php
@@ -1,0 +1,80 @@
+@php use Illuminate\Support\Str; @endphp
+<div>
+    <div class="card card-fluid">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-3">
+                <div class="w-100 w-md-50">
+                    <input type="search" wire:model.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug or meta title">
+                </div>
+                <div class="text-muted small">
+                    Showing {{ $posts->firstItem() ?? 0 }} - {{ $posts->lastItem() ?? 0 }} of {{ $posts->total() }} posts
+                </div>
+            </div>
+
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Title</th>
+                            <th>Category</th>
+                            <th>Featured</th>
+                            <th>Comments</th>
+                            <th>Indexing</th>
+                            <th>Updated</th>
+                            <th class="text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($posts as $post)
+                            <tr wire:key="post-{{ $post->id }}">
+                                <td>{{ $loop->iteration + ($posts->currentPage() - 1) * $posts->perPage() }}</td>
+                                <td>
+                                    <div class="font-weight-bold">{{ $post->title }}</div>
+                                    <div class="text-muted small"><code>{{ $post->slug }}</code></div>
+                                    @if ($post->meta_title)
+                                        <div class="text-muted small">Meta: {{ Str::limit($post->meta_title, 45) }}</div>
+                                    @endif
+                                </td>
+                                <td>
+                                    <div>{{ $post->category?->name ?? '—' }}</div>
+                                    <div class="text-muted small">
+                                        {{ $post->subCategory?->name ?? 'No sub category' }}
+                                    </div>
+                                </td>
+                                <td>
+                                    <button type="button" class="btn btn-sm {{ $post->is_featured ? 'btn-success' : 'btn-outline-secondary' }}" wire:click="toggleFeatured({{ $post->id }})">
+                                        {{ $post->is_featured ? 'Featured' : 'Not Featured' }}
+                                    </button>
+                                </td>
+                                <td>
+                                    <button type="button" class="btn btn-sm {{ $post->allow_comments ? 'btn-success' : 'btn-outline-secondary' }}" wire:click="toggleComments({{ $post->id }})">
+                                        {{ $post->allow_comments ? 'Allowed' : 'Disabled' }}
+                                    </button>
+                                </td>
+                                <td>
+                                    <button type="button" class="btn btn-sm {{ $post->is_indexable ? 'btn-success' : 'btn-outline-secondary' }}" wire:click="toggleIndexable({{ $post->id }})">
+                                        {{ $post->is_indexable ? 'Index' : 'No Index' }}
+                                    </button>
+                                </td>
+                                <td>{{ $post->updated_at?->format('d M, Y') }}</td>
+                                <td class="text-right">
+                                    <a href="{{ route('admin.posts.edit', $post) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                                    <button type="button" class="btn btn-sm btn-outline-danger" wire:click="deletePost({{ $post->id }})" onclick="confirm('Are you sure you want to delete this post?') || event.stopImmediatePropagation()">Delete</button>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="8" class="text-center text-muted">No posts found.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <div>
+                {{ $posts->links() }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Admin\CategoryController;
+use App\Http\Controllers\Admin\PostController;
 use App\Http\Controllers\Admin\SubCategoryController;
 
 Route::get('/', function () {
@@ -39,5 +40,6 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
        Route::resource('categories', CategoryController::class)->except(['show']);
        Route::resource('subcategories', SubCategoryController::class)->except(['show']);
+       Route::resource('posts', PostController::class)->only(['index', 'create', 'edit']);
     });
 });


### PR DESCRIPTION
## Summary
- add a posts table migration and model with metadata, thumbnail, and publishing options
- introduce Livewire PostForm and PostsTable components with CKEditor-powered editing, slug generation, and toggle actions
- wire new admin routes, pages, and navigation entry for managing posts from the dashboard

## Testing
- not run (vendor autoload missing in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9a55021348326a0b0dacca15336e3