### PR TITLE
Allow nullable Livewire post form fields

### DIFF
--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -18,11 +18,11 @@ class PostForm extends Component
 
     public ?Post $post = null;
 
-    public string $title = '';
-    public string $slug = '';
-    public string $description = '';
-    public string $category_id = '';
-    public string $sub_category_id = '';
+    public ?string $title = '';
+    public ?string $slug = '';
+    public ?string $description = '';
+    public ?string $category_id = '';
+    public ?string $sub_category_id = '';
     public bool $is_featured = false;
     public bool $allow_comments = true;
     public bool $is_indexable = true;


### PR DESCRIPTION
## Summary
- allow Livewire post form string properties to accept null values to avoid hydration errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a7e62030832680002daa822f4b65