### PR TITLE
Fix post form creation logic

### DIFF
--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -149,7 +149,9 @@ class PostForm extends Component
             $data['thumbnail_path'] = $this->thumbnail->store('posts', 'public');
         }
 
-        if ($this->post) {
+        unset($data['thumbnail']);
+
+        if ($this->post && $this->post->exists) {
             $this->post->update($data);
             $message = 'Post updated successfully.';
         } else {


### PR DESCRIPTION
## Summary
- ensure the admin post form only runs the update path when an existing post model is loaded
- remove the transient thumbnail validation field before persisting so mass-assignment works cleanly

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ae0ccc9483269db4911adaa9ea03