### PR TITLE
Add live search filters to post category selectors

### DIFF
--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -21,6 +21,8 @@
             <div class="form-row">
                 <div class="form-group col-md-6">
                     <label for="postCategory">Category <span class="text-danger">*</span></label>
+                    <input type="search" class="form-control mb-2" placeholder="Search categories..."
+                        wire:model.debounce.300ms="categorySearch">
                     <select id="postCategory" class="form-control @error('category_id') is-invalid @enderror" wire:model="category_id">
                         <option value="">Select category</option>
                         @foreach ($this->categories as $category)
@@ -33,6 +35,8 @@
                 </div>
                 <div class="form-group col-md-6">
                     <label for="postSubCategory">Sub Category</label>
+                    <input type="search" class="form-control mb-2" placeholder="Search sub categories..."
+                        wire:model.debounce.300ms="subCategorySearch" @disabled(! $category_id)>
                     <select id="postSubCategory" class="form-control @error('sub_category_id') is-invalid @enderror" wire:model="sub_category_id">
                         <option value="">None</option>
                         @foreach ($this->availableSubCategories as $subCategory)


### PR DESCRIPTION
## Summary
- add Livewire-powered search inputs for the post category and subcategory dropdowns
- filter available options by the typed query while keeping the current selection visible

## Testing
- `php artisan test` *(fails: missing vendor autoload because Composer install requires GitHub token and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b17198f88326a9df485a796b9213