### PR TITLE
Enhance post index live search

### DIFF
--- a/resources/views/livewire/admin/posts-table.blade.php
+++ b/resources/views/livewire/admin/posts-table.blade.php
@@ -4,7 +4,7 @@
         <div class="card-body">
             <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-3">
                 <div class="w-100 w-md-50">
-                    <input type="search" wire:model.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug or meta title">
+                    <input type="search" wire:model.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug, meta title, category or sub category">
                 </div>
                 <div class="text-muted small">
                     Showing {{ $posts->firstItem() ?? 0 }} - {{ $posts->lastItem() ?? 0 }} of {{ $posts->total() }} posts


### PR DESCRIPTION
## Summary
- trim the post index search term as it updates to keep pagination in sync
- expand the Livewire posts table query to match category and sub category names
- clarify the posts table search placeholder to reflect the broader filtering

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b38941808326ba65f630930aa787