### PR TITLE
Remove category search inputs from admin post form

### DIFF
--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -32,9 +32,6 @@ class PostForm extends Component
     public $thumbnail;
     public ?string $existingThumbnail = null;
 
-    public string $categorySearch = '';
-    public string $subCategorySearch = '';
-
     public bool $autoGenerateSlug = true;
 
     protected ?string $lastSyncedDescription = null;
@@ -79,11 +76,8 @@ class PostForm extends Component
     {
         if ($value === null || $value === '') {
             $this->sub_category_id = '';
-            $this->subCategorySearch = '';
             return;
         }
-
-        $this->subCategorySearch = '';
 
         if ($this->sub_category_id) {
             $isValid = SubCategory::where('id', $this->sub_category_id)
@@ -221,15 +215,7 @@ class PostForm extends Component
     #[Computed]
     public function categories()
     {
-        $categorySearchTerm = trim($this->categorySearch);
-
         $categories = Category::query()
-            ->when($categorySearchTerm !== '', function ($query) use ($categorySearchTerm) {
-                $query->where(function ($nested) use ($categorySearchTerm) {
-                    $nested->where('name', 'like', '%'.$categorySearchTerm.'%')
-                        ->orWhere('slug', 'like', '%'.$categorySearchTerm.'%');
-                });
-            })
             ->orderBy('name')
             ->get();
 
@@ -252,16 +238,8 @@ class PostForm extends Component
             return collect();
         }
 
-        $subCategorySearchTerm = trim($this->subCategorySearch);
-
         $subCategories = SubCategory::query()
             ->where('category_id', $this->category_id)
-            ->when($subCategorySearchTerm !== '', function ($query) use ($subCategorySearchTerm) {
-                $query->where(function ($nested) use ($subCategorySearchTerm) {
-                    $nested->where('name', 'like', '%'.$subCategorySearchTerm.'%')
-                        ->orWhere('slug', 'like', '%'.$subCategorySearchTerm.'%');
-                });
-            })
             ->orderBy('name')
             ->get();
 

--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -21,8 +21,6 @@
             <div class="form-row">
                 <div class="form-group col-md-6">
                     <label for="postCategory">Category <span class="text-danger">*</span></label>
-                    <input type="search" class="form-control mb-2" placeholder="Search categories..."
-                        wire:model.debounce.300ms="categorySearch">
                     <select id="postCategory" class="form-control @error('category_id') is-invalid @enderror" wire:model="category_id">
                         <option value="">Select category</option>
                         @foreach ($this->categories as $category)
@@ -35,8 +33,6 @@
                 </div>
                 <div class="form-group col-md-6">
                     <label for="postSubCategory">Sub Category</label>
-                    <input type="search" class="form-control mb-2" placeholder="Search sub categories..."
-                        wire:model.debounce.300ms="subCategorySearch" @disabled(! $category_id)>
                     <select id="postSubCategory" class="form-control @error('sub_category_id') is-invalid @enderror" wire:model="sub_category_id">
                         <option value="">None</option>
                         @foreach ($this->availableSubCategories as $subCategory)


### PR DESCRIPTION
## Summary
- remove category and subcategory search fields from the admin post form view
- streamline the PostForm Livewire component by dropping search-related state and queries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b842e9b08326b0d67a4024a2a413