### PR TITLE
Fix Livewire posts table search input

### DIFF
--- a/resources/views/livewire/admin/posts-table.blade.php
+++ b/resources/views/livewire/admin/posts-table.blade.php
@@ -4,7 +4,7 @@
         <div class="card-body">
             <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-3">
                 <div class="w-100 w-md-50">
-                    <input type="search" wire:model.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug, meta title, category or sub category">
+                    <input type="search" wire:model.live.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug, meta title, category or sub category">
                 </div>
                 <div class="text-muted small">
                     Showing {{ $posts->firstItem() ?? 0 }} - {{ $posts->lastItem() ?? 0 }} of {{ $posts->total() }} posts


### PR DESCRIPTION
## Summary
- ensure the posts table search input uses Livewire's live debounce binding so results update while typing

## Testing
- php artisan test *(fails: vendor directory with autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b9e276c48326a91eab14d90b8d75