### PR TITLE
Add search filters to category and subcategory tables

### DIFF
--- a/resources/views/back/pages/categories/index.blade.php
+++ b/resources/views/back/pages/categories/index.blade.php
@@ -19,6 +19,22 @@
 
         <div class="card card-fluid">
             <div class="card-body">
+                <form method="GET" action="{{ route('admin.categories.index') }}" class="mb-3">
+                    <div class="form-row align-items-center">
+                        <div class="col-sm-6 my-1">
+                            <input type="text" name="search" value="{{ request('search') }}" class="form-control"
+                                placeholder="Search categories...">
+                        </div>
+                        <div class="col-auto my-1">
+                            <button type="submit" class="btn btn-primary">Search</button>
+                        </div>
+                        @if (request('search'))
+                            <div class="col-auto my-1">
+                                <a href="{{ route('admin.categories.index') }}" class="btn btn-outline-secondary">Clear</a>
+                            </div>
+                        @endif
+                    </div>
+                </form>
                 <div class="table-responsive">
                     <table class="table">
                         <thead>

--- a/resources/views/back/pages/sub_categories/index.blade.php
+++ b/resources/views/back/pages/sub_categories/index.blade.php
@@ -19,6 +19,22 @@
 
         <div class="card card-fluid">
             <div class="card-body">
+                <form method="GET" action="{{ route('admin.subcategories.index') }}" class="mb-3">
+                    <div class="form-row align-items-center">
+                        <div class="col-sm-6 my-1">
+                            <input type="text" name="search" value="{{ request('search') }}" class="form-control"
+                                placeholder="Search sub categories...">
+                        </div>
+                        <div class="col-auto my-1">
+                            <button type="submit" class="btn btn-primary">Search</button>
+                        </div>
+                        @if (request('search'))
+                            <div class="col-auto my-1">
+                                <a href="{{ route('admin.subcategories.index') }}" class="btn btn-outline-secondary">Clear</a>
+                            </div>
+                        @endif
+                    </div>
+                </form>
                 <div class="table-responsive">
                     <table class="table">
                         <thead>


### PR DESCRIPTION
## Summary
- add optional search filtering to the category index query and surface a search form in the table view
- enable searching sub categories by name, slug, or parent category and expose the filter UI in the listing
- keep pagination links aligned with the active filter via query string persistence

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d9baf6b06c8326a48360dd4d2064e8