### PR TITLE
Add admin user management with permission-aware navigation

### DIFF
--- a/app/Http/Controllers/Admin/UserManagementController.php
+++ b/app/Http/Controllers/Admin/UserManagementController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class UserManagementController extends Controller
+{
+    public function index()
+    {
+        return view('back.pages.users.index', [
+            'pageTitle' => 'User Management',
+        ]);
+    }
+}

--- a/app/Livewire/Admin/UsersTable.php
+++ b/app/Livewire/Admin/UsersTable.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\User;
+use App\UserStatus;
+use App\UserType;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class UsersTable extends Component
+{
+    use WithPagination;
+
+    #[Url(as: 'search', except: '')]
+    public string $search = '';
+
+    #[Url(as: 'role', except: '')]
+    public string $roleFilter = '';
+
+    #[Url(as: 'status', except: '')]
+    public string $statusFilter = '';
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingRoleFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingStatusFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function resetFilters(): void
+    {
+        $this->search = '';
+        $this->roleFilter = '';
+        $this->statusFilter = '';
+    }
+
+    public function changeRole(int $userId, string $role): void
+    {
+        $this->ensureCanManageUsers();
+
+        $role = trim($role);
+
+        if (! in_array($role, $this->availableRoleValues(), true)) {
+            session()->flash('error', 'Invalid role selected.');
+
+            return;
+        }
+
+        $user = User::findOrFail($userId);
+
+        if ($user->roleKey() === $role) {
+            return;
+        }
+
+        $user->type = UserType::from($role);
+        $user->save();
+
+        session()->flash('success', 'User role updated successfully.');
+    }
+
+    public function changeStatus(int $userId, string $status): void
+    {
+        $this->ensureCanManageUsers();
+
+        $status = trim($status);
+
+        if (! in_array($status, $this->availableStatusValues(), true)) {
+            session()->flash('error', 'Invalid status selected.');
+
+            return;
+        }
+
+        $user = User::findOrFail($userId);
+
+        if ($user->statusKey() === $status) {
+            return;
+        }
+
+        $user->status = UserStatus::from($status);
+        $user->save();
+
+        session()->flash('success', 'User status updated successfully.');
+    }
+
+    public function render()
+    {
+        $users = User::query()
+            ->when($this->search !== '', function ($query) {
+                $query->where(function ($innerQuery) {
+                    $searchTerm = "%{$this->search}%";
+
+                    $innerQuery->where('name', 'like', $searchTerm)
+                        ->orWhere('email', 'like', $searchTerm)
+                        ->orWhere('username', 'like', $searchTerm);
+                });
+            })
+            ->when($this->roleFilter !== '', function ($query) {
+                $query->where('type', $this->roleFilter);
+            })
+            ->when($this->statusFilter !== '', function ($query) {
+                $query->where('status', $this->statusFilter);
+            })
+            ->orderByDesc('created_at')
+            ->paginate(15);
+
+        return view('livewire.admin.users-table', [
+            'users' => $users,
+            'roleOptions' => $this->roleOptions(),
+            'statusOptions' => $this->statusOptions(),
+        ]);
+    }
+
+    /**
+     * Ensure the authenticated user can manage users.
+     */
+    protected function ensureCanManageUsers(): void
+    {
+        $user = Auth::user();
+
+        if (! $user || ! $user->hasPermission('manage_users')) {
+            abort(403);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function availableRoleValues(): array
+    {
+        return array_map(static fn (UserType $type) => $type->value, UserType::cases());
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function availableStatusValues(): array
+    {
+        return array_map(static fn (UserStatus $status) => $status->value, UserStatus::cases());
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    protected function roleOptions(): array
+    {
+        $rolesConfig = config('roles', []);
+
+        return array_map(function (UserType $type) use ($rolesConfig) {
+            $key = $type->value;
+            $label = $rolesConfig[$key]['label'] ?? ucfirst(str_replace('_', ' ', $key));
+
+            return [
+                'value' => $key,
+                'label' => $label,
+            ];
+        }, UserType::cases());
+    }
+
+    /**
+     * @return array<int, array{value: string, label: string}>
+     */
+    protected function statusOptions(): array
+    {
+        return array_map(function (UserStatus $status) {
+            $key = $status->value;
+            $label = ucfirst(str_replace('_', ' ', $key));
+
+            return [
+                'value' => $key,
+                'label' => $label,
+            ];
+        }, UserStatus::cases());
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -126,6 +126,30 @@ class User extends Authenticatable
     }
 
     /**
+     * Get the current status key for the user.
+     */
+    public function statusKey(): string
+    {
+        if ($this->status instanceof UserStatus) {
+            return $this->status->value;
+        }
+
+        if (is_string($this->status) && $this->status !== '') {
+            return $this->status;
+        }
+
+        return UserStatus::Pending->value;
+    }
+
+    /**
+     * Get the human readable label for the user's status.
+     */
+    public function statusLabel(): string
+    {
+        return ucfirst(str_replace('_', ' ', $this->statusKey()));
+    }
+
+    /**
      * Get the permissions granted to the user's role.
      *
      * @return list<string>

--- a/resources/views/back/layout/pages-layout.blade.php
+++ b/resources/views/back/layout/pages-layout.blade.php
@@ -372,68 +372,62 @@
                 <nav id="stacked-menu" class="stacked-menu">
                     <!-- .menu -->
                     <ul class="menu">
-                        <!-- .menu-item -->
-                        <li class="menu-item has-active">
+                        @php
+                            $adminUser = auth()->user();
+                            $canManageContent = $adminUser?->hasPermission('manage_content');
+                            $canAccessPosts = $adminUser?->hasAnyPermission('manage_content', 'publish_posts', 'edit_any_post', 'create_posts', 'submit_posts');
+                            $canViewSettings = $adminUser?->hasAnyPermission('manage_content', 'manage_users');
+                            $canManageUsers = $adminUser?->hasPermission('manage_users');
+                        @endphp
+
+                        <li class="menu-item {{ request()->routeIs('admin.dashboard') ? 'has-active' : '' }}">
                             <a href="{{ route('admin.dashboard') }}" class="menu-link"><span class="menu-icon fas fa-home"></span> <span class="menu-text">Dashboard</span></a>
-                        </li><!-- /.menu-item -->
-                        <li class="menu-header">Blog Management</li>
-                        <li class="menu-item {{ request()->routeIs('admin.categories.*') ? 'has-active' : '' }}">
-                            <a href="{{ route('admin.categories.index') }}" class="menu-link"><span class="menu-icon oi oi-folder"></span> <span class="menu-text">Categories</span></a>
                         </li>
-                        <li class="menu-item {{ request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
-                            <a href="{{ route('admin.subcategories.index') }}" class="menu-link"><span class="menu-icon oi oi-layers"></span> <span class="menu-text">Sub Categories</span></a>
-                        </li>
-                        <li class="menu-item {{ request()->routeIs('admin.posts.*') ? 'has-active' : '' }}">
-                            <a href="{{ route('admin.posts.index') }}" class="menu-link"><span class="menu-icon oi oi-document"></span> <span class="menu-text">Posts</span></a>
-                        </li>
-                        <!-- .menu-item -->
-                        <li class="menu-item has-child {{ request()->routeIs('admin.settings*') ? 'has-active' : '' }}">
-                            <a href="#" class="menu-link"><span class="menu-icon oi oi-wrench"></span> <span class="menu-text">Setting</span></a> <!-- child menu -->
-                            <ul class="menu">
-                                <li class="menu-item {{ request()->routeIs('admin.settings') ? 'has-active' : '' }}">
-                                    <a href="{{ route('admin.settings') }}" class="menu-link">General Setting</a>
+
+                        @if ($canManageContent || $canAccessPosts)
+                            <li class="menu-header">Blog Management</li>
+
+                            @if ($canManageContent)
+                                <li class="menu-item {{ request()->routeIs('admin.categories.*') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.categories.index') }}" class="menu-link"><span class="menu-icon oi oi-folder"></span> <span class="menu-text">Categories</span></a>
                                 </li>
-                            </ul><!-- /child menu -->
-                        </li><!-- /.menu-item -->
-                        <!-- .menu-item -->
-                        <li class="menu-item has-child">
-                            <a href="#" class="menu-link"><span class="menu-icon oi oi-person"></span> <span class="menu-text">User</span></a> <!-- child menu -->
+                                <li class="menu-item {{ request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.subcategories.index') }}" class="menu-link"><span class="menu-icon oi oi-layers"></span> <span class="menu-text">Sub Categories</span></a>
+                                </li>
+                            @endif
+
+                            @if ($canAccessPosts)
+                                <li class="menu-item {{ request()->routeIs('admin.posts.*') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.posts.index') }}" class="menu-link"><span class="menu-icon oi oi-document"></span> <span class="menu-text">Posts</span></a>
+                                </li>
+                            @endif
+                        @endif
+
+                        @if ($canViewSettings)
+                            <li class="menu-item has-child {{ request()->routeIs('admin.settings*') ? 'has-active' : '' }}">
+                                <a href="#" class="menu-link"><span class="menu-icon oi oi-wrench"></span> <span class="menu-text">Setting</span></a>
+                                <ul class="menu">
+                                    <li class="menu-item {{ request()->routeIs('admin.settings') ? 'has-active' : '' }}">
+                                        <a href="{{ route('admin.settings') }}" class="menu-link">General Setting</a>
+                                    </li>
+                                </ul>
+                            </li>
+                        @endif
+
+                        <li class="menu-item has-child {{ request()->routeIs('admin.profile') || request()->routeIs('admin.users.*') ? 'has-active' : '' }}">
+                            <a href="#" class="menu-link"><span class="menu-icon oi oi-person"></span> <span class="menu-text">User</span></a>
                             <ul class="menu">
-                                <li class="menu-item">
+                                <li class="menu-item {{ request()->routeIs('admin.profile') ? 'has-active' : '' }}">
                                     <a href="{{ route('admin.profile') }}" class="menu-link">Profile</a>
                                 </li>
 
-                                <li class="menu-item">
-                                    <a href="user-notification-settings.html" class="menu-link">Notification Settings</a>
-                                </li>
-                            </ul><!-- /child menu -->
-                        </li><!-- /.menu-item -->
-                        <!-- .menu-item -->
-                        <li class="menu-item has-child">
-                            <a href="#" class="menu-link"><span class="menu-icon oi oi-browser"></span> <span class="menu-text">Layouts</span> <span class="badge badge-subtle badge-success">+4</span></a> <!-- child menu -->
-                            <ul class="menu">
-                                <li class="menu-item">
-                                    <a href="layout-blank.html" class="menu-link">Blank Page</a>
-                                </li>
-
-                            </ul><!-- /child menu -->
-                        </li><!-- /.menu-item -->
-                        <!-- .menu-item -->
-                        <li class="menu-item">
-                            <a href="landing-page.html" class="menu-link"><span class="menu-icon fas fa-rocket"></span> <span class="menu-text">Landing Page</span></a>
-                        </li><!-- /.menu-item -->
-                        <!-- .menu-header -->
-                        <li class="menu-header">Interfaces </li><!-- /.menu-header -->
-                        <!-- .menu-item -->
-                        <li class="menu-item has-child">
-                            <a href="#" class="menu-link"><span class="menu-icon oi oi-puzzle-piece"></span> <span class="menu-text">Components</span></a> <!-- child menu -->
-                            <ul class="menu">
-                                <li class="menu-item">
-                                    <a href="component-general.html" class="menu-link">General</a>
-                                </li>
-
-                            </ul><!-- /child menu -->
-                        </li><!-- /.menu-item -->
+                                @if ($canManageUsers)
+                                    <li class="menu-item {{ request()->routeIs('admin.users.*') ? 'has-active' : '' }}">
+                                        <a href="{{ route('admin.users.index') }}" class="menu-link">User Management</a>
+                                    </li>
+                                @endif
+                            </ul>
+                        </li>
                     </ul><!-- /.menu -->
                 </nav><!-- /.stacked-menu -->
             </div><!-- /.aside-menu -->

--- a/resources/views/back/pages/users/index.blade.php
+++ b/resources/views/back/pages/users/index.blade.php
@@ -1,0 +1,5 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'User Management')
+@section('content')
+    <livewire:admin.users-table />
+@endsection

--- a/resources/views/livewire/admin/users-table.blade.php
+++ b/resources/views/livewire/admin/users-table.blade.php
@@ -1,0 +1,126 @@
+<div>
+    <header class="page-title-bar">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+            <div>
+                <h1 class="page-title">User Management</h1>
+                <p class="text-muted mb-0">Manage user roles, statuses, and access to the admin panel.</p>
+            </div>
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session()->has('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+
+        @if (session()->has('error'))
+            <div class="alert alert-danger">{{ session('error') }}</div>
+        @endif
+
+        <div class="card card-fluid">
+            <div class="card-body">
+                <div class="form-row align-items-center mb-3">
+                    <div class="col-sm-4 my-1">
+                        <input
+                            type="search"
+                            class="form-control"
+                            placeholder="Search users by name, email, or username"
+                            wire:model.live.debounce.400ms="search"
+                        >
+                    </div>
+                    <div class="col-sm-3 my-1">
+                        <select class="form-control" wire:model.live="roleFilter">
+                            <option value="">All roles</option>
+                            @foreach ($roleOptions as $option)
+                                <option value="{{ $option['value'] }}">{{ $option['label'] }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-sm-3 my-1">
+                        <select class="form-control" wire:model.live="statusFilter">
+                            <option value="">All statuses</option>
+                            @foreach ($statusOptions as $option)
+                                <option value="{{ $option['value'] }}">{{ $option['label'] }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    @if ($search !== '' || $roleFilter !== '' || $statusFilter !== '')
+                        <div class="col-auto my-1">
+                            <button type="button" class="btn btn-outline-secondary" wire:click="resetFilters">Clear filters</button>
+                        </div>
+                    @endif
+                </div>
+
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>User</th>
+                                <th>Role</th>
+                                <th>Status</th>
+                                <th>Joined</th>
+                                <th class="text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($users as $user)
+                                @php
+                                    $statusKey = $user->statusKey();
+                                    $statusClasses = [
+                                        'active' => 'badge-success',
+                                        'pending' => 'badge-warning',
+                                        'inactive' => 'badge-secondary',
+                                        'rejected' => 'badge-danger',
+                                    ];
+                                    $statusClass = $statusClasses[$statusKey] ?? 'badge-secondary';
+                                @endphp
+                                <tr wire:key="user-{{ $user->id }}">
+                                    <td>{{ $loop->iteration + ($users->currentPage() - 1) * $users->perPage() }}</td>
+                                    <td>
+                                        <div class="d-flex align-items-center">
+                                            <img src="{{ $user->avatar }}" alt="{{ $user->name }}" class="rounded-circle mr-2" width="40" height="40">
+                                            <div>
+                                                <div class="font-weight-bold">{{ $user->name }}</div>
+                                                <div class="text-muted small">{{ $user->email }}</div>
+                                                <div class="text-muted small">@{{ $user->username }}</div>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <select class="form-control form-control-sm" wire:change="changeRole({{ $user->id }}, $event.target.value)">
+                                            @foreach ($roleOptions as $option)
+                                                <option value="{{ $option['value'] }}" @selected($option['value'] === $user->roleKey())>{{ $option['label'] }}</option>
+                                            @endforeach
+                                        </select>
+                                        <div class="text-muted small mt-1">{{ $user->roleSummary() }}</div>
+                                    </td>
+                                    <td>
+                                        <span class="badge {{ $statusClass }} text-uppercase">{{ $user->statusLabel() }}</span>
+                                        <select class="form-control form-control-sm mt-2" wire:change="changeStatus({{ $user->id }}, $event.target.value)">
+                                            @foreach ($statusOptions as $option)
+                                                <option value="{{ $option['value'] }}" @selected($option['value'] === $statusKey)>{{ $option['label'] }}</option>
+                                            @endforeach
+                                        </select>
+                                    </td>
+                                    <td>{{ $user->created_at?->format('d M, Y') }}</td>
+                                    <td class="text-right">
+                                        <a href="mailto:{{ $user->email }}" class="btn btn-sm btn-outline-secondary">Contact</a>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="text-center text-muted">No users found.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                <div>
+                    {{ $users->links() }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\PostController;
 use App\Http\Controllers\Admin\SubCategoryController;
+use App\Http\Controllers\Admin\UserManagementController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -49,5 +50,9 @@ Route::prefix('admin')->name('admin.')->group(function () {
        Route::resource('posts', PostController::class)
            ->only(['index', 'create', 'edit'])
            ->middleware('permission:manage_content,publish_posts,edit_any_post,create_posts,submit_posts');
+
+       Route::get('users', [UserManagementController::class, 'index'])
+           ->name('users.index')
+           ->middleware('permission:manage_users');
     });
 });

--- a/tests/Feature/AdminMenuVisibilityTest.php
+++ b/tests/Feature/AdminMenuVisibilityTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\UserType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminMenuVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_author_cannot_see_management_menus(): void
+    {
+        $user = User::factory()->create([
+            'type' => UserType::Author,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.dashboard'));
+
+        $response->assertOk();
+        $response->assertDontSee(route('admin.categories.index'), false);
+        $response->assertDontSee('Categories', false);
+        $response->assertDontSee(route('admin.settings'), false);
+        $response->assertDontSee('User Management', false);
+        $response->assertSee(route('admin.posts.index'), false);
+    }
+
+    public function test_administrator_can_see_all_management_menus(): void
+    {
+        $user = User::factory()->create([
+            'type' => UserType::Administrator,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.dashboard'));
+
+        $response->assertOk();
+        $response->assertSee(route('admin.categories.index'), false);
+        $response->assertSee('Categories', false);
+        $response->assertSee(route('admin.users.index'), false);
+        $response->assertSee('User Management', false);
+    }
+
+    public function test_author_cannot_access_user_management_page(): void
+    {
+        $user = User::factory()->create([
+            'type' => UserType::Author,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.users.index'));
+
+        $response->assertForbidden();
+    }
+
+    public function test_administrator_can_access_user_management_page(): void
+    {
+        $user = User::factory()->create([
+            'type' => UserType::Administrator,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.users.index'));
+
+        $response->assertOk();
+        $response->assertSee('User Management', false);
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin user management page powered by a Livewire table for updating roles and statuses
- hide sidebar items when the signed-in user lacks the relevant permissions and surface a user management link when allowed
- extend the user model with status helpers and add feature coverage for menu visibility and access control

## Testing
- `php artisan test` *(fails: vendor dependencies are missing because composer install requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c38201c483269c356aa47a893258