### PR TITLE
Restrict user management to super admins

### DIFF
--- a/app/Livewire/Admin/UsersTable.php
+++ b/app/Livewire/Admin/UsersTable.php
@@ -128,7 +128,7 @@ class UsersTable extends Component
     {
         $user = Auth::user();
 
-        if (! $user || ! $user->hasPermission('manage_users')) {
+        if (! $user || $user->type !== UserType::SuperAdmin) {
             abort(403);
         }
     }

--- a/config/roles.php
+++ b/config/roles.php
@@ -14,14 +14,12 @@ return [
         'permissions' => [
             'access_admin_panel',
             'manage_content',
-            'manage_users',
             'publish_posts',
             'edit_any_post',
             'create_posts',
             'edit_own_posts',
             'submit_posts',
             'schedule_posts',
-            'assign_roles',
         ],
     ],
     UserType::Editor->value => [

--- a/tests/Unit/UserRolePermissionsTest.php
+++ b/tests/Unit/UserRolePermissionsTest.php
@@ -30,6 +30,21 @@ class UserRolePermissionsTest extends TestCase
         $this->assertTrue($user->hasPermission('manage_content'));
     }
 
+    public function test_only_super_admin_can_manage_users(): void
+    {
+        $administrator = User::factory()->create([
+            'type' => UserType::Administrator,
+        ]);
+
+        $this->assertFalse($administrator->hasPermission('manage_users'));
+
+        $superAdmin = User::factory()->create([
+            'type' => UserType::SuperAdmin,
+        ]);
+
+        $this->assertTrue($superAdmin->hasPermission('manage_users'));
+    }
+
     public function test_subscriber_cannot_access_admin_panel(): void
     {
         $user = User::factory()->create([


### PR DESCRIPTION
## Summary
- restrict user management interactions in the admin users table to super admins
- adjust the administrator role definition so user management permissions are only granted by super admins
- add a regression test ensuring only super admins retain the manage_users permission

## Testing
- php artisan test *(fails: dependencies could not be installed because GitHub returned 403 during composer install)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fbc7780483269a59b67b03f11cc1