### PR TITLE
Add database-backed roles and permissions support

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -40,9 +40,11 @@ class PostController extends Controller
             return false;
         }
 
-        $role = $user->type instanceof UserType ? $user->type->value : (string) $user->type;
+        if ($user->hasAnyRole(UserType::SuperAdmin->value, UserType::Administrator->value)) {
+            return true;
+        }
 
-        if (in_array($role, [UserType::SuperAdmin->value, UserType::Administrator->value], true)) {
+        if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {
             return true;
         }
 

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -291,9 +291,11 @@ class PostForm extends Component
             return false;
         }
 
-        $role = $user->type instanceof UserType ? $user->type->value : (string) $user->type;
+        if ($user->hasAnyRole(UserType::SuperAdmin->value, UserType::Administrator->value)) {
+            return true;
+        }
 
-        if (in_array($role, [UserType::SuperAdmin->value, UserType::Administrator->value], true)) {
+        if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {
             return true;
         }
 

--- a/app/Livewire/Admin/PostsTable.php
+++ b/app/Livewire/Admin/PostsTable.php
@@ -130,9 +130,11 @@ class PostsTable extends Component
             return false;
         }
 
-        $role = $user->type instanceof UserType ? $user->type->value : (string) $user->type;
+        if ($user->hasAnyRole(UserType::SuperAdmin->value, UserType::Administrator->value)) {
+            return true;
+        }
 
-        return in_array($role, [UserType::SuperAdmin->value, UserType::Administrator->value], true);
+        return $user->hasAnyPermission('manage_content', 'edit_any_post');
     }
 
     protected function canManagePost(Post $post): bool

--- a/app/Models/Concerns/HasRolesAndPermissions.php
+++ b/app/Models/Concerns/HasRolesAndPermissions.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Collection;
+
+trait HasRolesAndPermissions
+{
+    /**
+     * @return BelongsToMany<Role, self>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class)->withTimestamps();
+    }
+
+    /**
+     * @return BelongsToMany<Permission, self>
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class)->withTimestamps();
+    }
+
+    /**
+     * Assign one or many roles to the model.
+     */
+    public function assignRole(string|int|Role|array ...$roles): static
+    {
+        $storedRoles = $this->resolveRoles($roles);
+
+        if ($storedRoles->isEmpty()) {
+            return $this;
+        }
+
+        $this->roles()->syncWithoutDetaching($storedRoles->pluck('id')->all());
+
+        if (! $this->primaryRole()) {
+            $this->syncPrimaryRoleAttribute($storedRoles->first());
+        }
+
+        return $this->load('roles');
+    }
+
+    /**
+     * Replace any currently assigned roles with the provided set.
+     */
+    public function syncRoles(string|int|Role|array ...$roles): static
+    {
+        $storedRoles = $this->resolveRoles($roles);
+
+        $this->roles()->sync($storedRoles->pluck('id')->all());
+
+        $this->syncPrimaryRoleAttribute($storedRoles->first());
+
+        return $this->load('roles');
+    }
+
+    /**
+     * Remove the provided role from the model.
+     */
+    public function removeRole(string|int|Role $role): static
+    {
+        $storedRole = $this->resolveRole($role);
+
+        $this->roles()->detach($storedRole);
+
+        if ($this->primaryRole()?->is($storedRole)) {
+            $this->syncPrimaryRoleAttribute($this->roles()->first());
+        }
+
+        return $this->load('roles');
+    }
+
+    /**
+     * Determine if the model has (at least) one of the provided roles.
+     */
+    public function hasRole(string|int|Role|array ...$roles): bool
+    {
+        $storedRoles = $this->resolveRoles($roles);
+
+        if ($storedRoles->isEmpty()) {
+            return false;
+        }
+
+        $this->loadMissing('roles');
+
+        return $storedRoles->contains(fn (Role $role) => $this->roles->contains('id', $role->id));
+    }
+
+    /**
+     * Determine if the model has any of the provided roles.
+     */
+    public function hasAnyRole(string|int|Role|array ...$roles): bool
+    {
+        return $this->hasRole(...$roles);
+    }
+
+    /**
+     * Determine if the model has all of the provided roles.
+     */
+    public function hasAllRoles(string|int|Role|array ...$roles): bool
+    {
+        $storedRoles = $this->resolveRoles($roles);
+
+        if ($storedRoles->isEmpty()) {
+            return false;
+        }
+
+        $this->loadMissing('roles');
+
+        return $storedRoles->every(fn (Role $role) => $this->roles->contains('id', $role->id));
+    }
+
+    /**
+     * Grant one or many direct permissions to the model.
+     */
+    public function givePermissionTo(string|int|Permission|array ...$permissions): static
+    {
+        $storedPermissions = $this->resolvePermissions($permissions);
+
+        if ($storedPermissions->isEmpty()) {
+            return $this;
+        }
+
+        $this->permissions()->syncWithoutDetaching($storedPermissions->pluck('id')->all());
+
+        return $this->load('permissions');
+    }
+
+    /**
+     * Sync direct permissions for the model.
+     */
+    public function syncPermissions(string|int|Permission|array ...$permissions): static
+    {
+        $storedPermissions = $this->resolvePermissions($permissions);
+
+        $this->permissions()->sync($storedPermissions->pluck('id')->all());
+
+        return $this->load('permissions');
+    }
+
+    /**
+     * Revoke the provided direct permission(s) from the model.
+     */
+    public function revokePermissionTo(string|int|Permission|array ...$permissions): static
+    {
+        $storedPermissions = $this->resolvePermissions($permissions);
+
+        if ($storedPermissions->isEmpty()) {
+            return $this;
+        }
+
+        $this->permissions()->detach($storedPermissions->pluck('id')->all());
+
+        return $this->load('permissions');
+    }
+
+    /**
+     * Determine if the model has the provided permission via roles or direct assignment.
+     */
+    public function hasPermissionTo(string|Permission $permission): bool
+    {
+        $permissionModel = $permission instanceof Permission
+            ? $permission
+            : Permission::query()->where('slug', $permission)->first();
+
+        if (! $permissionModel) {
+            if (method_exists($this, 'permissionNames')) {
+                /** @var list<string> $names */
+                $names = $this->permissionNames();
+
+                if (in_array('*', $names, true) || in_array((string) $permission, $names, true)) {
+                    return true;
+                }
+            }
+
+            $this->loadMissing('permissions', 'roles.permissions');
+
+            return $this->allPermissions()->contains(fn (Permission $perm) => $perm->slug === $permission || $perm->slug === '*');
+        }
+
+        return $this->hasPermissionModel($permissionModel);
+    }
+
+    /**
+     * Determine if the model has the provided permission directly assigned.
+     */
+    public function hasDirectPermission(string|Permission $permission): bool
+    {
+        $this->loadMissing('permissions');
+
+        if ($permission instanceof Permission) {
+            return $this->permissions->contains('id', $permission->id);
+        }
+
+        return $this->permissions->contains('slug', $permission) || $this->permissions->contains('slug', '*');
+    }
+
+    /**
+     * Retrieve all permissions assigned to the model via roles or directly.
+     */
+    public function allPermissions(): EloquentCollection
+    {
+        $this->loadMissing('permissions', 'roles.permissions');
+
+        /** @var EloquentCollection<int, Permission> $direct */
+        $direct = $this->permissions;
+
+        /** @var EloquentCollection<int, Permission> $viaRoles */
+        $viaRoles = $this->roles->flatMap(fn (Role $role) => $role->permissions)->unique('id');
+
+        return $direct->merge($viaRoles)->unique('id');
+    }
+
+    /**
+     * Get the primary/most relevant role for the model.
+     */
+    public function primaryRole(): ?Role
+    {
+        $this->loadMissing('roles');
+
+        if ($this->roles->isEmpty()) {
+            return null;
+        }
+
+        $typeAttribute = (string) ($this->getAttribute('type') ?? '');
+
+        if ($typeAttribute !== '') {
+            $match = $this->roles->firstWhere('slug', $typeAttribute);
+
+            if ($match) {
+                return $match;
+            }
+        }
+
+        return $this->roles
+            ->sortByDesc(fn (Role $role) => optional($role->pivot)->created_at)
+            ->first();
+    }
+
+    /**
+     * Normalize the provided role inputs into stored models.
+     */
+    protected function resolveRoles(array $roles): Collection
+    {
+        return collect($roles)
+            ->flatten()
+            ->filter(fn ($role) => $role !== null && $role !== '')
+            ->map(fn ($role) => $this->resolveRole($role))
+            ->unique(fn (Role $role) => $role->getKey())
+            ->values();
+    }
+
+    /**
+     * Resolve a single role value into a stored model instance.
+     */
+    protected function resolveRole(string|int|Role $role): Role
+    {
+        if ($role instanceof Role) {
+            return $role;
+        }
+
+        $query = Role::query();
+
+        if (is_numeric($role)) {
+            return $query->whereKey((int) $role)->firstOrFail();
+        }
+
+        return $query
+            ->where('slug', $role)
+            ->orWhere('name', $role)
+            ->firstOrFail();
+    }
+
+    /**
+     * Normalize permission inputs into stored models.
+     */
+    protected function resolvePermissions(array $permissions): Collection
+    {
+        return collect($permissions)
+            ->flatten()
+            ->filter(fn ($permission) => $permission !== null && $permission !== '')
+            ->map(fn ($permission) => $this->resolvePermission($permission))
+            ->unique(fn (Permission $permission) => $permission->getKey())
+            ->values();
+    }
+
+    /**
+     * Resolve a single permission value into a stored model instance.
+     */
+    protected function resolvePermission(string|int|Permission $permission): Permission
+    {
+        if ($permission instanceof Permission) {
+            return $permission;
+        }
+
+        $query = Permission::query();
+
+        if (is_numeric($permission)) {
+            return $query->whereKey((int) $permission)->firstOrFail();
+        }
+
+        return $query
+            ->where('slug', $permission)
+            ->orWhere('name', $permission)
+            ->firstOrFail();
+    }
+
+    /**
+     * Persist the primary role representation on the model if applicable.
+     */
+    protected function syncPrimaryRoleAttribute(?Role $role): void
+    {
+        if (! $this->isFillable('type') && ! array_key_exists('type', $this->getAttributes())) {
+            return;
+        }
+
+        $value = $role?->slug;
+
+        if ($value === null) {
+            $value = config('roles.default', 'subscriber');
+        }
+
+        $this->forceFill(['type' => $value]);
+        $this->saveQuietly();
+    }
+
+    /**
+     * Determine if a permission model is assigned either directly or via roles.
+     */
+    protected function hasPermissionModel(Permission $permission): bool
+    {
+        $this->loadMissing('permissions', 'roles.permissions');
+
+        if ($this->permissions->contains('id', $permission->id)) {
+            return true;
+        }
+
+        if ($this->permissions->contains('slug', '*')) {
+            return true;
+        }
+
+        if ($permission->slug === '*') {
+            return $this->permissions->isNotEmpty() || $this->roles->isNotEmpty();
+        }
+
+        return $this->roles->contains(fn (Role $role) => $role->permissions->contains('id', $permission->id) || $role->permissions->contains('slug', '*'));
+    }
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+    ];
+
+    /**
+     * @return BelongsToMany<Role, Permission>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class)->withTimestamps();
+    }
+
+    /**
+     * @return BelongsToMany<User, Permission>
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'summary',
+    ];
+
+    /**
+     * @return BelongsToMany<User, Role>
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+
+    /**
+     * @return BelongsToMany<Permission, Role>
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class)->withTimestamps();
+    }
+}

--- a/database/migrations/2025_10_10_000100_create_roles_and_permissions_tables.php
+++ b/database/migrations/2025_10_10_000100_create_roles_and_permissions_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->text('summary')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['role_id', 'user_id']);
+        });
+
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['permission_id', 'role_id']);
+        });
+
+        Schema::create('permission_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['permission_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permission_user');
+        Schema::dropIfExists('permission_role');
+        Schema::dropIfExists('role_user');
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,9 @@ class DatabaseSeeder extends Seeder
 //            'email' => 'test@example.com',
 //        ]);
 
-        $this->call(UserSeeder::class);
+        $this->call([
+            RolePermissionSeeder::class,
+            UserSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class RolePermissionSeeder extends Seeder
+{
+    /**
+     * Seed the application's roles and permissions.
+     */
+    public function run(): void
+    {
+        $definitions = config('roles', []);
+
+        foreach ($definitions as $slug => $definition) {
+            if (! is_array($definition)) {
+                continue;
+            }
+
+            $role = Role::query()->updateOrCreate(
+                ['slug' => $slug],
+                [
+                    'name' => $definition['label'] ?? Str::headline($slug),
+                    'summary' => $definition['summary'] ?? null,
+                ]
+            );
+
+            $permissions = $definition['permissions'] ?? [];
+
+            $permissionIds = collect($permissions)
+                ->flatten()
+                ->filter(fn ($permission) => is_string($permission) && $permission !== '')
+                ->map(function (string $permission) {
+                    $label = $permission === '*'
+                        ? 'All Permissions'
+                        : Str::headline(str_replace(['*', '.'], ' ', $permission));
+
+                    return Permission::query()->updateOrCreate(
+                        ['slug' => $permission],
+                        ['name' => $label !== '' ? $label : Str::headline($permission)]
+                    );
+                })
+                ->pluck('id')
+                ->all();
+
+            $role->permissions()->sync($permissionIds);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -54,7 +54,7 @@ class UserSeeder extends Seeder
         ];
 
         foreach ($users as $role => $attributes) {
-            User::updateOrCreate(
+            $user = User::updateOrCreate(
                 ['email' => $attributes['email']],
                 array_merge($attributes, [
                     'password' => $password,
@@ -62,6 +62,8 @@ class UserSeeder extends Seeder
                     'status' => UserStatus::Active,
                 ])
             );
+
+            $user->syncRoles($role);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add role and permission models with migrations and database seeders generated from the existing configuration
- introduce a reusable HasRolesAndPermissions trait that mirrors Spatie-style helpers for assigning and checking permissions on users
- update admin components and controllers to rely on the new role and permission checks while keeping legacy fallbacks

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ff3b81a88326b6cb5364e286887e