### PR TITLE
Handle enum type when determining primary role

### DIFF
--- a/app/Models/Concerns/HasRolesAndPermissions.php
+++ b/app/Models/Concerns/HasRolesAndPermissions.php
@@ -228,7 +228,17 @@ trait HasRolesAndPermissions
             return null;
         }
 
-        $typeAttribute = (string) ($this->getAttribute('type') ?? '');
+        $typeAttribute = $this->getAttribute('type');
+
+        if ($typeAttribute instanceof \BackedEnum) {
+            $typeAttribute = $typeAttribute->value;
+        } elseif (is_string($typeAttribute) || is_int($typeAttribute)) {
+            $typeAttribute = (string) $typeAttribute;
+        } elseif (is_object($typeAttribute) && method_exists($typeAttribute, '__toString')) {
+            $typeAttribute = (string) $typeAttribute;
+        } else {
+            $typeAttribute = '';
+        }
 
         if ($typeAttribute !== '') {
             $match = $this->roles->firstWhere('slug', $typeAttribute);


### PR DESCRIPTION
## Summary
- normalize the stored user type attribute before matching roles to prevent string conversion errors

## Testing
- php artisan test tests/Unit/UserRolePermissionsTest.php *(fails: vendor autoload not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da043ec9948326af87c2962a696f11