### PR TITLE
Fix post creation permission middleware

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,7 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
        Route::resource('posts', PostController::class)
            ->only(['index', 'create', 'edit'])
-           ->middleware('permission:manage_content,publish_posts,edit_any_post,create_posts,submit_posts');
+           ->middleware('permission:manage_content|publish_posts|edit_any_post|create_posts|submit_posts');
 
        Route::resource('roles', RoleController::class)
            ->except(['show'])


### PR DESCRIPTION
## Summary
- allow authors with any relevant content permission to access the admin post routes by using the correct separator in the permission middleware

## Testing
- not run (environment lacks Composer dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68da097ed2f08326a3b4b95c0a1be594