### PR TITLE
Fix permission middleware parsing for post creation access

### DIFF
--- a/app/Http/Middleware/EnsureUserHasPermission.php
+++ b/app/Http/Middleware/EnsureUserHasPermission.php
@@ -21,7 +21,7 @@ class EnsureUserHasPermission
             return redirect()->route('admin.login');
         }
 
-        $permissions = ! empty($permissions) ? $permissions : ['access_admin_panel'];
+        $permissions = ! empty($permissions) ? $this->expandPermissions($permissions) : ['access_admin_panel'];
 
         if ($user->hasAnyPermission(...$permissions)) {
             return $next($request);
@@ -32,5 +32,22 @@ class EnsureUserHasPermission
         }
 
         abort(Response::HTTP_FORBIDDEN, __('You do not have permission to perform this action.'));
+    }
+
+    /**
+     * Expand delimited permission strings into a unique flat list.
+     *
+     * @param  list<string>  $permissions
+     * @return list<string>
+     */
+    protected function expandPermissions(array $permissions): array
+    {
+        return collect($permissions)
+            ->flatMap(fn (string $permission) => preg_split('/[|,]/', $permission) ?: [])
+            ->map(fn (string $permission) => trim($permission))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/tests/Feature/AdminMenuVisibilityTest.php
+++ b/tests/Feature/AdminMenuVisibilityTest.php
@@ -64,4 +64,16 @@ class AdminMenuVisibilityTest extends TestCase
         $response->assertOk();
         $response->assertSee('User Management', false);
     }
+
+    public function test_author_can_access_post_creation_page(): void
+    {
+        $user = User::factory()->create([
+            'type' => UserType::Author,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('admin.posts.create'));
+
+        $response->assertOk();
+        $response->assertSee('Create Post', false);
+    }
 }


### PR DESCRIPTION
## Summary
- normalize permission middleware input so `permission:` routes honour piped or comma-delimited permission strings
- add a feature test ensuring authors can access the post creation page via the updated middleware

## Testing
- php artisan test *(fails: composer install cannot download dependencies due to GitHub 403/token requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68da0b4eab30832690b3fca5300227e9