### PR TITLE
Allow super admins to bypass permission checks

### DIFF
--- a/app/Http/Middleware/EnsureUserHasPermission.php
+++ b/app/Http/Middleware/EnsureUserHasPermission.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\UserType;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +23,14 @@ class EnsureUserHasPermission
         }
 
         $permissions = ! empty($permissions) ? $this->expandPermissions($permissions) : ['access_admin_panel'];
+
+        if (method_exists($user, 'hasPermission') && $user->hasPermission('*')) {
+            return $next($request);
+        }
+
+        if (method_exists($user, 'hasAnyRole') && $user->hasAnyRole(UserType::SuperAdmin->value)) {
+            return $next($request);
+        }
 
         if ($user->hasAnyPermission(...$permissions)) {
             return $next($request);


### PR DESCRIPTION
## Summary
- allow users with the super admin role or wildcard permission to bypass the EnsureUserHasPermission middleware

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da0e0befe88326a25aea9456cd7b50