### PR TITLE
Restrict post creation to dedicated permission

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -17,6 +17,8 @@ class PostController extends Controller
 
     public function create()
     {
+        abort_unless($this->canCreatePosts(), 403);
+
         return view('back.pages.posts.create', [
             'pageTitle' => 'Create Post',
         ]);
@@ -49,5 +51,20 @@ class PostController extends Controller
         }
 
         return (int) $post->user_id === (int) $user->id;
+    }
+
+    protected function canCreatePosts(): bool
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->hasAnyRole(UserType::SuperAdmin->value, UserType::Administrator->value)) {
+            return true;
+        }
+
+        return $user->hasAnyPermission('manage_content', 'create_posts');
     }
 }

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -40,11 +40,11 @@ class PostForm extends Component
 
     public function mount(?Post $post = null): void
     {
-        $this->post = $post;
-
-        if ($post && ! $this->canManagePost($post)) {
+        if (! $this->canManagePost($post)) {
             abort(403);
         }
+
+        $this->post = $post;
 
         if ($post) {
             $this->title = $post->title;
@@ -114,7 +114,7 @@ class PostForm extends Component
 
     public function save(): mixed
     {
-        if ($this->post && ! $this->canManagePost($this->post)) {
+        if (! $this->canManagePost($this->post)) {
             abort(403);
         }
 
@@ -295,11 +295,11 @@ class PostForm extends Component
             return true;
         }
 
-        if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {
-            return true;
+        if (! $post) {
+            return $user->hasAnyPermission('manage_content', 'create_posts');
         }
 
-        if (! $post) {
+        if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- prevent users with only edit permissions from accessing the create post screen
- require the create_posts or manage_content permissions when handling new post creation in Livewire
- harden Livewire post form authorization checks for both mounting and saving

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da129b020883269aac55ba3e2be72d