### PR TITLE
Allow submit permission to create posts

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -65,6 +65,6 @@ class PostController extends Controller
             return true;
         }
 
-        return $user->hasAnyPermission('manage_content', 'create_posts');
+        return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts');
     }
 }

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -296,7 +296,7 @@ class PostForm extends Component
         }
 
         if (! $post) {
-            return $user->hasAnyPermission('manage_content', 'create_posts');
+            return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts');
         }
 
         if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {


### PR DESCRIPTION
## Summary
- allow users with the submit_posts permission to reach the post creation page
- extend the Livewire post form guard to accept submit_posts when creating new content

## Testing
- `php artisan test` *(fails: missing vendor directory in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da14c8cf908326a638db3c9ed84652