### PR TITLE
Ensure role permissions include config defaults

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -180,15 +180,16 @@ class User extends Authenticatable
      */
     public function permissionNames(): array
     {
-        $permissions = $this->allPermissions()->pluck('slug')->unique()->values()->all();
+        $databasePermissions = $this->allPermissions()->pluck('slug');
 
-        if ($permissions === []) {
-            $definition = $this->roleDefinition();
+        $configPermissions = collect(config('roles.' . $this->roleKey() . '.permissions', []));
 
-            return $definition['permissions'] ?? [];
-        }
-
-        return $permissions;
+        return $databasePermissions
+            ->merge($configPermissions)
+            ->filter(fn ($permission) => is_string($permission) && $permission !== '')
+            ->unique()
+            ->values()
+            ->all();
     }
 
     /**


### PR DESCRIPTION
## Summary
- merge stored role permissions with configuration defaults when resolving a user's effective permission names so recently added abilities are respected

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da1694fc50832686deb17fcf967889