### PR TITLE
Allow edit permission to create posts

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -65,6 +65,6 @@ class PostController extends Controller
             return true;
         }
 
-        return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts');
+        return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts', 'edit_any_post');
     }
 }

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -296,7 +296,7 @@ class PostForm extends Component
         }
 
         if (! $post) {
-            return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts');
+            return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts', 'edit_any_post');
         }
 
         if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {


### PR DESCRIPTION
## Summary
- allow users with the edit_any_post permission to reach the post creation screen
- align the Livewire post form permission check with the controller guard

## Testing
- `php artisan test` *(fails: missing vendor autoload in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da1a8a8b4883268dc219304b01df12