### PR TITLE
Allow edit_any_post permission to reach post creation page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -54,7 +54,7 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
        Route::get('posts/create', [PostController::class, 'create'])
            ->name('posts.create')
-           ->middleware('permission:manage_content|create_posts|submit_posts');
+           ->middleware('permission:manage_content|create_posts|submit_posts|edit_any_post');
 
        Route::get('posts/{post}/edit', [PostController::class, 'edit'])
            ->name('posts.edit')


### PR DESCRIPTION
## Summary
- allow users who possess the `edit_any_post` capability to access the post creation route so authorization checks stay consistent with the controller and Livewire component

## Testing
- `php artisan test` *(fails: missing vendor autoload before installing composer dependencies; composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da1dd2e9f48326ba2004b8c06bd82c