### PR TITLE
Ensure contributors can create posts without edit-any permission

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -65,6 +65,6 @@ class PostController extends Controller
             return true;
         }
 
-        return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts', 'edit_any_post');
+        return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts');
     }
 }

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -296,7 +296,7 @@ class PostForm extends Component
         }
 
         if (! $post) {
-            return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts', 'edit_any_post');
+            return $user->hasAnyPermission('manage_content', 'create_posts', 'submit_posts');
         }
 
         if ($user->hasAnyPermission('manage_content', 'edit_any_post')) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,11 +50,11 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
        Route::get('posts', [PostController::class, 'index'])
            ->name('posts.index')
-           ->middleware('permission:manage_content|publish_posts|edit_any_post|create_posts|submit_posts');
+           ->middleware('permission:manage_content|publish_posts|create_posts|submit_posts');
 
        Route::get('posts/create', [PostController::class, 'create'])
            ->name('posts.create')
-           ->middleware('permission:manage_content|create_posts|submit_posts|edit_any_post');
+           ->middleware('permission:manage_content|create_posts|submit_posts');
 
        Route::get('posts/{post}/edit', [PostController::class, 'edit'])
            ->name('posts.edit')


### PR DESCRIPTION
## Summary
- update the post creation gate logic to only require manage, create, or submit permissions
- drop the `edit_any_post` middleware requirement from the posts index and create routes so contributors can reach them

## Testing
- php -l app/Http/Controllers/Admin/PostController.php
- php -l app/Livewire/Admin/PostForm.php
- php -l routes/web.php

------
https://chatgpt.com/codex/tasks/task_e_68da20451bc88326b70cb799b341f4b4