### PR TITLE
Allow contributors to access post creation form

### DIFF
--- a/app/Http/Middleware/EnsureUserHasPermission.php
+++ b/app/Http/Middleware/EnsureUserHasPermission.php
@@ -55,8 +55,27 @@ class EnsureUserHasPermission
             ->flatMap(fn (string $permission) => preg_split('/[|,]/', $permission) ?: [])
             ->map(fn (string $permission) => trim($permission))
             ->filter()
+            ->flatMap(fn (string $permission) => $this->resolveAliases($permission))
             ->unique()
             ->values()
             ->all();
+    }
+
+    /**
+     * Resolve known permission aliases.
+     *
+     * Treat submit_posts as satisfying create_posts requirements so that
+     * contributors can open the post creation form without being blocked by
+     * the middleware.
+     *
+     * @return list<string>
+     */
+    protected function resolveAliases(string $permission): array
+    {
+        $aliases = [
+            'create_posts' => ['create_posts', 'submit_posts'],
+        ];
+
+        return $aliases[$permission] ?? [$permission];
     }
 }

--- a/tests/Feature/Admin/PostCreationAccessTest.php
+++ b/tests/Feature/Admin/PostCreationAccessTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\UserType;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class PostCreationAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function contributor_can_access_the_post_creation_form(): void
+    {
+        $this->seed(RolePermissionSeeder::class);
+
+        $user = User::factory()->create([
+            'type' => UserType::Contributor,
+        ]);
+
+        $user->assignRole(UserType::Contributor->value);
+
+        $response = $this->actingAs($user)->get(route('admin.posts.create'));
+
+        $response->assertOk();
+    }
+
+    /** @test */
+    public function submit_post_permission_is_treated_as_create_permission(): void
+    {
+        Route::middleware('web')->get('/testing/create-permission', fn () => 'ok')
+            ->middleware('permission:create_posts');
+
+        $this->seed(RolePermissionSeeder::class);
+
+        $user = User::factory()->create([
+            'type' => UserType::Contributor,
+        ]);
+
+        $user->assignRole(UserType::Contributor->value);
+
+        $response = $this->actingAs($user)->get('/testing/create-permission');
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- treat `submit_posts` as an alias for `create_posts` in the permission middleware so contributors are not blocked from the post creation page
- add feature coverage to confirm contributors can open the create form and satisfy `create_posts` checks via `submit_posts`

## Testing
- php artisan test --filter=PostCreationAccessTest *(fails: composer install requires GitHub access and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da240bceb08326a4b77b3d74407532