### PR TITLE
Integrate Spatie permissions system

### DIFF
--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -3,32 +3,83 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Str;
+use Spatie\Permission\Contracts\Permission as PermissionContract;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Models\Permission as SpatiePermission;
 
-class Permission extends Model
+class Permission extends SpatiePermission implements PermissionContract
 {
     use HasFactory;
 
     protected $fillable = [
         'name',
         'slug',
+        'guard_name',
         'description',
     ];
+
+    protected $attributes = [
+        'guard_name' => 'web',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function findByName(string $name, ?string $guardName = null): static
+    {
+        $guardName ??= app(PermissionRegistrar::class)->getDefaultGuardName(static::class);
+
+        $permission = static::query()
+            ->where('slug', $name)
+            ->where('guard_name', $guardName)
+            ->first();
+
+        if (! $permission) {
+            throw PermissionDoesNotExist::named($name);
+        }
+
+        return $permission;
+    }
+
+    public static function findOrCreate(string $name, ?string $guardName = null): static
+    {
+        $guardName ??= app(PermissionRegistrar::class)->getDefaultGuardName(static::class);
+
+        try {
+            return static::findByName($name, $guardName);
+        } catch (PermissionDoesNotExist) {
+            // Create a new record
+        }
+
+        return static::query()->create([
+            'slug' => $name,
+            'name' => Str::headline(str_replace(['*', '.', '_'], ' ', $name)),
+            'guard_name' => $guardName,
+        ]);
+    }
 
     /**
      * @return BelongsToMany<Role, Permission>
      */
     public function roles(): BelongsToMany
     {
-        return $this->belongsToMany(Role::class)->withTimestamps();
+        return $this->belongsToMany(
+            Role::class,
+            config('permission.table_names.role_has_permissions')
+        );
     }
 
     /**
-     * @return BelongsToMany<User, Permission>
+     * @return MorphToMany<User>
      */
-    public function users(): BelongsToMany
+    public function users(): MorphToMany
     {
-        return $this->belongsToMany(User::class)->withTimestamps();
+        return $this->morphedByMany(User::class, 'model', config('permission.table_names.model_has_permissions'));
     }
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -3,25 +3,73 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Str;
+use Spatie\Permission\Contracts\Role as RoleContract;
+use Spatie\Permission\Exceptions\RoleDoesNotExist;
+use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Models\Role as SpatieRole;
 
-class Role extends Model
+class Role extends SpatieRole implements RoleContract
 {
     use HasFactory;
 
     protected $fillable = [
         'name',
         'slug',
+        'guard_name',
         'summary',
     ];
 
-    /**
-     * @return BelongsToMany<User, Role>
-     */
-    public function users(): BelongsToMany
+    protected $attributes = [
+        'guard_name' => 'web',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function findByName(string $name, ?string $guardName = null): static
     {
-        return $this->belongsToMany(User::class)->withTimestamps();
+        $guardName ??= app(PermissionRegistrar::class)->getDefaultGuardName(static::class);
+
+        $role = static::query()
+            ->where('slug', $name)
+            ->where('guard_name', $guardName)
+            ->first();
+
+        if (! $role) {
+            throw RoleDoesNotExist::named($name);
+        }
+
+        return $role;
+    }
+
+    public static function findOrCreate(string $name, ?string $guardName = null): static
+    {
+        $guardName ??= app(PermissionRegistrar::class)->getDefaultGuardName(static::class);
+
+        try {
+            return static::findByName($name, $guardName);
+        } catch (RoleDoesNotExist) {
+            // Continue and create the role
+        }
+
+        return static::query()->create([
+            'slug' => $name,
+            'name' => Str::headline(str_replace(['*', '.', '_'], ' ', $name)),
+            'guard_name' => $guardName,
+        ]);
+    }
+
+    /**
+     * @return MorphToMany<User>
+     */
+    public function users(): MorphToMany
+    {
+        return $this->morphedByMany(User::class, 'model', config('permission.table_names.model_has_roles'));
     }
 
     /**
@@ -29,6 +77,9 @@ class Role extends Model
      */
     public function permissions(): BelongsToMany
     {
-        return $this->belongsToMany(Permission::class)->withTimestamps();
+        return $this->belongsToMany(
+            Permission::class,
+            config('permission.table_names.role_has_permissions')
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "laravel/tinker": "^2.10.1",
         "livewire/livewire": "^3.6",
         "phpmailer/phpmailer": "^6.10",
-        "sawastacks/kropify-laravel": "^3.0"
+        "sawastacks/kropify-laravel": "^3.0",
+        "spatie/laravel-permission": "^6.11"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,36 @@
+<?php
+
+use DateInterval;
+
+return [
+    'models' => [
+        'permission' => App\Models\Permission::class,
+        'role' => App\Models\Role::class,
+    ],
+
+    'table_names' => [
+        'roles' => 'roles',
+        'permissions' => 'permissions',
+        'model_has_permissions' => 'model_has_permissions',
+        'model_has_roles' => 'model_has_roles',
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        'model_morph_key' => 'model_id',
+    ],
+
+    'display_permission_in_exception' => true,
+
+    'display_role_in_exception' => true,
+
+    'enable_wildcard_permission' => true,
+
+    'teams' => false,
+
+    'cache' => [
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
+        'key' => 'spatie.permission.cache',
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2025_10_10_000100_create_roles_and_permissions_tables.php
+++ b/database/migrations/2025_10_10_000100_create_roles_and_permissions_tables.php
@@ -13,45 +13,45 @@ return new class extends Migration
     {
         Schema::create('roles', function (Blueprint $table) {
             $table->id();
-            $table->string('slug')->unique();
             $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('guard_name');
             $table->text('summary')->nullable();
             $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
         });
 
         Schema::create('permissions', function (Blueprint $table) {
             $table->id();
-            $table->string('slug')->unique();
             $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('guard_name');
             $table->text('description')->nullable();
             $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
         });
 
-        Schema::create('role_user', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->timestamps();
-
-            $table->unique(['role_id', 'user_id']);
-        });
-
-        Schema::create('permission_role', function (Blueprint $table) {
-            $table->id();
+        Schema::create('role_has_permissions', function (Blueprint $table) {
             $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
             $table->foreignId('role_id')->constrained()->cascadeOnDelete();
-            $table->timestamps();
 
-            $table->unique(['permission_id', 'role_id']);
+            $table->primary(['permission_id', 'role_id']);
         });
 
-        Schema::create('permission_user', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->timestamps();
+        Schema::create('model_has_roles', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
 
-            $table->unique(['permission_id', 'user_id']);
+            $table->primary(['role_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('model_has_permissions', function (Blueprint $table) {
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->morphs('model');
+
+            $table->primary(['permission_id', 'model_id', 'model_type']);
         });
     }
 
@@ -60,9 +60,9 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('permission_user');
-        Schema::dropIfExists('permission_role');
-        Schema::dropIfExists('role_user');
+        Schema::dropIfExists('model_has_permissions');
+        Schema::dropIfExists('model_has_roles');
+        Schema::dropIfExists('role_has_permissions');
         Schema::dropIfExists('permissions');
         Schema::dropIfExists('roles');
     }


### PR DESCRIPTION
## Summary
- replace the custom roles/permissions trait with an implementation built on top of Spatie\'s HasRoles API and automatic cache syncing
- extend the Role and Permission models plus the database schema to match Spatie\'s tables and guard requirements
- add the published package configuration, seed updates, and controller guard/cache handling while requiring spatie/laravel-permission in composer

## Testing
- unable to run tests because Composer cannot download new dependencies in this environment

------
https://chatgpt.com/codex/tasks/task_e_68da2d79c2708326b7b6f3a3901a9c6b