### PR TITLE
Fix DateInterval import warning in permission config

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -1,7 +1,5 @@
 <?php
 
-use DateInterval;
-
 return [
     'models' => [
         'permission' => App\Models\Permission::class,
@@ -29,7 +27,7 @@ return [
     'teams' => false,
 
     'cache' => [
-        'expiration_time' => DateInterval::createFromDateString('24 hours'),
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
         'key' => 'spatie.permission.cache',
         'store' => 'default',
     ],


### PR DESCRIPTION
## Summary
- remove the unused DateInterval import in the permission configuration
- reference DateInterval with its global namespace to avoid PHP warning

## Testing
- php -l config/permission.php

------
https://chatgpt.com/codex/tasks/task_e_68da31410ecc832680c997844be26d4a