### PR TITLE
Add slug columns to Spatie permission tables

### DIFF
--- a/database/migrations/2025_09_29_074334_create_permission_tables.php
+++ b/database/migrations/2025_09_29_074334_create_permission_tables.php
@@ -24,10 +24,12 @@ return new class extends Migration
             // $table->engine('InnoDB');
             $table->bigIncrements('id'); // permission id
             $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('slug');
             $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
             $table->timestamps();
 
             $table->unique(['name', 'guard_name']);
+            $table->unique(['slug', 'guard_name']);
         });
 
         Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
@@ -38,12 +40,15 @@ return new class extends Migration
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
             }
             $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('slug');
             $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
             $table->timestamps();
             if ($teams || config('permission.testing')) {
                 $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+                $table->unique([$columnNames['team_foreign_key'], 'slug', 'guard_name'], 'roles_team_slug_guard_name_unique');
             } else {
                 $table->unique(['name', 'guard_name']);
+                $table->unique(['slug', 'guard_name']);
             }
         });
 


### PR DESCRIPTION
## Summary
- add slug columns and unique indexes to the permissions and roles tables so the custom models can persist slugs

## Testing
- not run (vendor directory is missing in the provided workspace)


------
https://chatgpt.com/codex/tasks/task_e_68da3d294a0483269223c40c002522db