### PR TITLE
Refactor role and permission architecture around registry

### DIFF
--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -5,16 +5,21 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Permission;
 use App\Models\Role;
+use App\Support\Permissions\RoleRegistry;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Spatie\Permission\PermissionRegistrar;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
+use Spatie\Permission\PermissionRegistrar;
 
 class RoleController extends Controller
 {
+    public function __construct(protected RoleRegistry $roles)
+    {
+    }
+
     /**
      * Display a listing of the roles.
      */
@@ -155,6 +160,7 @@ class RoleController extends Controller
     protected function availablePermissions(): Collection
     {
         return Permission::query()
+            ->where('guard_name', $this->guardName())
             ->orderByRaw("CASE WHEN slug = '*' THEN 0 ELSE 1 END")
             ->orderBy('name')
             ->get();
@@ -275,6 +281,6 @@ class RoleController extends Controller
      */
     protected function guardName(): string
     {
-        return config('auth.defaults.guard', 'web');
+        return $this->roles->guard();
     }
 }

--- a/app/Livewire/Admin/UsersTable.php
+++ b/app/Livewire/Admin/UsersTable.php
@@ -2,8 +2,8 @@
 
 namespace App\Livewire\Admin;
 
-use App\Models\Role;
 use App\Models\User;
+use App\Support\Permissions\RoleRegistry;
 use App\UserStatus;
 use App\UserType;
 use Illuminate\Support\Facades\Auth;
@@ -138,7 +138,7 @@ class UsersTable extends Component
      */
     protected function availableRoleValues(): array
     {
-        return Role::query()->pluck('slug')->all();
+        return app(RoleRegistry::class)->slugs();
     }
 
     /**
@@ -154,14 +154,7 @@ class UsersTable extends Component
      */
     protected function roleOptions(): array
     {
-        return Role::query()
-            ->orderBy('name')
-            ->get()
-            ->map(fn (Role $role) => [
-                'value' => $role->slug,
-                'label' => $role->name,
-            ])
-            ->all();
+        return app(RoleRegistry::class)->options();
     }
 
     /**

--- a/app/Providers/PermissionServiceProvider.php
+++ b/app/Providers/PermissionServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Providers;
+
+use App\Support\Permissions\RoleRegistry;
+use Illuminate\Support\ServiceProvider;
+
+class PermissionServiceProvider extends ServiceProvider
+{
+    /**
+     * Register application services.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(RoleRegistry::class, function ($app) {
+            $config = $app['config']->get('roles', []);
+
+            return RoleRegistry::make(is_array($config) ? $config : []);
+        });
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Support/Permissions/RoleDefinition.php
+++ b/app/Support/Permissions/RoleDefinition.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Support\Permissions;
+
+use Illuminate\Support\Str;
+
+/**
+ * Immutable data object describing an application role and its permissions.
+ */
+final class RoleDefinition
+{
+    /**
+     * @param  list<string>  $permissions
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $label,
+        public readonly ?string $summary,
+        public readonly array $permissions,
+    ) {
+    }
+
+    /**
+     * Build a role definition from configuration values.
+     */
+    public static function fromConfig(string $slug, array $config): self
+    {
+        $label = (string) ($config['label'] ?? Str::headline(str_replace(['*', '.', '_'], ' ', $slug)));
+        $summary = $config['summary'] ?? null;
+
+        $permissions = collect($config['permissions'] ?? [])
+            ->flatten()
+            ->filter(fn ($permission) => is_string($permission) && $permission !== '')
+            ->values()
+            ->all();
+
+        return new self(
+            $slug,
+            $label !== '' ? $label : Str::headline($slug),
+            $summary !== '' ? $summary : null,
+            $permissions,
+        );
+    }
+}

--- a/app/Support/Permissions/RoleRegistry.php
+++ b/app/Support/Permissions/RoleRegistry.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Support\Permissions;
+
+use App\UserType;
+use Illuminate\Support\Collection;
+
+/**
+ * Central registry for application role metadata defined in configuration.
+ */
+class RoleRegistry
+{
+    /** @var Collection<string, RoleDefinition> */
+    protected Collection $definitions;
+
+    public function __construct(
+        protected string $guard,
+        protected string $defaultRole,
+        Collection $definitions,
+        protected bool $pruneMissing = false,
+    ) {
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * Build a registry instance from the application configuration.
+     */
+    public static function make(array $config): self
+    {
+        $guard = (string) ($config['guard'] ?? config('auth.defaults.guard', 'web'));
+        $rawRoles = is_array($config['roles'] ?? null) ? $config['roles'] : [];
+        $prune = (bool) ($config['prune_missing'] ?? false);
+
+        $definitions = collect($rawRoles)
+            ->filter(fn ($role) => is_array($role))
+            ->mapWithKeys(fn (array $role, string $slug) => [
+                $slug => RoleDefinition::fromConfig($slug, $role),
+            ]);
+
+        $default = (string) ($config['default'] ?? UserType::Subscriber->value);
+
+        if ($default === '' || ! $definitions->has($default)) {
+            $default = $definitions->keys()->first()
+                ?? UserType::Subscriber->value;
+        }
+
+        return new self($guard, $default, $definitions, $prune);
+    }
+
+    public function guard(): string
+    {
+        return $this->guard;
+    }
+
+    public function defaultRole(): string
+    {
+        return $this->defaultRole;
+    }
+
+    /**
+     * @return Collection<string, RoleDefinition>
+     */
+    public function definitions(): Collection
+    {
+        return $this->definitions;
+    }
+
+    public function definition(string $slug): ?RoleDefinition
+    {
+        return $this->definitions->get($slug);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function slugs(): array
+    {
+        return $this->definitions->keys()->values()->all();
+    }
+
+    /**
+     * @return list<array{value: string, label: string}>
+     */
+    public function options(): array
+    {
+        return $this->definitions
+            ->map(fn (RoleDefinition $definition) => [
+                'value' => $definition->slug,
+                'label' => $definition->label,
+            ])
+            ->values()
+            ->all();
+    }
+
+    public function shouldPruneMissing(): bool
+    {
+        return $this->pruneMissing;
+    }
+
+    /**
+     * Retrieve the permission slugs declared in configuration.
+     *
+     * @return list<string>
+     */
+    public function declaredPermissions(): array
+    {
+        return $this->definitions
+            ->flatMap(fn (RoleDefinition $definition) => $definition->permissions)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\PermissionServiceProvider::class,
 ];

--- a/config/roles.php
+++ b/config/roles.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\UserType;
+
+return [
+    'guard' => env('PERMISSION_GUARD', config('auth.defaults.guard', 'web')),
+
+    'default' => UserType::Subscriber->value,
+
+    'prune_missing' => false,
+
+    'roles' => [
+        UserType::SuperAdmin->value => [
+            'label' => 'সুপার অ্যাডমিন',
+            'summary' => null,
+            'permissions' => ['*', 'manage_roles'],
+        ],
+        UserType::Administrator->value => [
+            'label' => 'অ্যাডমিনিস্ট্রেটর',
+            'summary' => null,
+            'permissions' => [
+                'access_admin_panel',
+                'manage_content',
+                'publish_posts',
+                'edit_any_post',
+                'create_posts',
+                'edit_own_posts',
+                'submit_posts',
+                'schedule_posts',
+            ],
+        ],
+        UserType::Editor->value => [
+            'label' => 'এডিটর',
+            'summary' => null,
+            'permissions' => [
+                'access_admin_panel',
+                'publish_posts',
+                'edit_any_post',
+                'create_posts',
+                'edit_own_posts',
+                'review_posts',
+                'manage_categories',
+                'verify_content',
+            ],
+        ],
+        UserType::Author->value => [
+            'label' => 'লেখক/রিপোর্টার',
+            'summary' => null,
+            'permissions' => [
+                'access_admin_panel',
+                'create_posts',
+                'edit_own_posts',
+                'delete_own_posts',
+                'upload_media',
+                'submit_posts',
+            ],
+        ],
+        UserType::Contributor->value => [
+            'label' => 'কন্ট্রিবিউটর',
+            'summary' => null,
+            'permissions' => [
+                'access_admin_panel',
+                'create_posts',
+                'submit_posts',
+            ],
+        ],
+        UserType::Subscriber->value => [
+            'label' => 'সাবস্ক্রাইবার',
+            'summary' => null,
+            'permissions' => ['read_and_comment'],
+        ],
+    ],
+];


### PR DESCRIPTION
## Summary
- add a dedicated permission service provider and role registry built from a new roles configuration file
- refactor user role helpers, admin controllers, and Livewire tables to leverage the centralized registry data
- overhaul the seeder to sync roles/permissions from configuration with optional pruning support

## Testing
- php artisan test *(fails: vendor autoloader missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da45908b488326a23d844bf58cf4d7