### PR TITLE
Add summary column to roles table

### DIFF
--- a/database/migrations/2025_10_05_000002_add_summary_to_roles_table.php
+++ b/database/migrations/2025_10_05_000002_add_summary_to_roles_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $rolesTable = config('permission.table_names.roles', 'roles');
+
+        Schema::table($rolesTable, static function (Blueprint $table) {
+            $table->string('summary')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $rolesTable = config('permission.table_names.roles', 'roles');
+
+        Schema::table($rolesTable, static function (Blueprint $table) {
+            $table->dropColumn('summary');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration to introduce an optional `summary` column to the roles table defined by the permission package
- ensure the column is dropped when rolling the migration back

## Testing
- not run (composer install requires a GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da47b370ec8326ab51d4657d48c093