### PR TITLE
Implement SEO-friendly frontend with sitemap and RSS feed

### DIFF
--- a/app/Http/Controllers/Frontend/FeedController.php
+++ b/app/Http/Controllers/Frontend/FeedController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use App\Models\GeneralSetting;
+use App\Models\Post;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
+
+class FeedController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $settings = $this->settings();
+
+        $posts = Post::query()
+            ->with('author')
+            ->where('is_indexable', true)
+            ->latest('created_at')
+            ->take(20)
+            ->get();
+
+        $updated = optional($posts->first())->updated_at ?? now();
+
+        return response()
+            ->view('front.feed', [
+                'posts' => $posts,
+                'settings' => $settings,
+                'updated' => $updated,
+            ])
+            ->header('Content-Type', 'application/rss+xml');
+    }
+
+    protected function settings(): ?GeneralSetting
+    {
+        return Cache::remember('general_settings', now()->addHour(), function () {
+            return GeneralSetting::query()->first();
+        });
+    }
+}

--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use App\Models\GeneralSetting;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class HomeController extends Controller
+{
+    public function index(Request $request)
+    {
+        $settings = $this->settings();
+
+        $postsQuery = Post::query()
+            ->with(['category', 'author'])
+            ->where('is_indexable', true)
+            ->latest('created_at');
+
+        $search = trim((string) $request->query('search'));
+
+        if ($search !== '') {
+            $postsQuery->where(function ($query) use ($search) {
+                $query->where('title', 'like', "%{$search}%")
+                    ->orWhere('meta_title', 'like', "%{$search}%")
+                    ->orWhere('meta_description', 'like', "%{$search}%");
+            });
+        }
+
+        $posts = $postsQuery->paginate(9)->withQueryString();
+
+        $seo = [
+            'title' => $settings?->site_title ?? config('app.name'),
+            'description' => $settings?->site_meta_description ?? $settings?->site_description ?? config('app.name') . ' blog and news updates.',
+            'keywords' => $settings?->site_meta_keywords,
+            'type' => 'website',
+            'canonical' => route('home'),
+            'indexable' => true,
+        ];
+
+        if ($search !== '') {
+            $seo['title'] = 'Search results for "' . $search . '" | ' . ($settings?->site_title ?? config('app.name'));
+            $seo['description'] = 'Articles and news matching the search query "' . $search . '".';
+            $seo['indexable'] = false;
+        }
+
+        return view('front.home', compact('posts', 'seo', 'settings', 'search'));
+    }
+
+    protected function settings(): ?GeneralSetting
+    {
+        return Cache::remember('general_settings', now()->addHour(), function () {
+            return GeneralSetting::query()->first();
+        });
+    }
+}

--- a/app/Http/Controllers/Frontend/PostController.php
+++ b/app/Http/Controllers/Frontend/PostController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use App\Models\GeneralSetting;
+use App\Models\Post;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+class PostController extends Controller
+{
+    public function show(Post $post)
+    {
+        $settings = $this->settings();
+
+        $image = $post->thumbnail_path ? Storage::url($post->thumbnail_path) : null;
+
+        $seo = [
+            'title' => $post->meta_title ?: $post->title,
+            'description' => $post->meta_description ?: $post->excerpt,
+            'keywords' => $post->meta_keywords ?: $settings?->site_meta_keywords,
+            'type' => 'article',
+            'canonical' => route('posts.show', $post),
+            'indexable' => (bool) $post->is_indexable,
+            'image' => $image,
+            'published_time' => optional($post->created_at)->toIso8601String(),
+            'modified_time' => optional($post->updated_at ?? $post->created_at)->toIso8601String(),
+            'author' => $post->author?->name,
+        ];
+
+        return view('front.post', compact('post', 'seo', 'settings'));
+    }
+
+    protected function settings(): ?GeneralSetting
+    {
+        return Cache::remember('general_settings', now()->addHour(), function () {
+            return GeneralSetting::query()->first();
+        });
+    }
+}

--- a/app/Http/Controllers/Frontend/SitemapController.php
+++ b/app/Http/Controllers/Frontend/SitemapController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use Illuminate\Http\Response;
+
+class SitemapController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $posts = Post::query()
+            ->where('is_indexable', true)
+            ->orderByDesc('updated_at')
+            ->get(['slug', 'updated_at', 'created_at']);
+
+        $lastUpdated = optional($posts->first())->updated_at ?? now();
+
+        return response()
+            ->view('front.sitemap', [
+                'posts' => $posts,
+                'lastUpdated' => $lastUpdated,
+            ])
+            ->header('Content-Type', 'application/xml');
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,9 +2,12 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class Post extends Model
 {
@@ -32,6 +35,11 @@ class Post extends Model
         'is_indexable' => 'boolean',
     ];
 
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
     public function category(): BelongsTo
     {
         return $this->belongsTo(Category::class);
@@ -45,5 +53,19 @@ class Post extends Model
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    protected function thumbnailUrl(): Attribute
+    {
+        return Attribute::get(function () {
+            return $this->thumbnail_path ? Storage::url($this->thumbnail_path) : null;
+        });
+    }
+
+    protected function excerpt(): Attribute
+    {
+        return Attribute::get(function () {
+            return Str::limit(strip_tags((string) $this->description), 160);
+        });
     }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,5 @@
 User-agent: *
-Disallow:
+Disallow: /admin/
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/resources/views/front/feed.blade.php
+++ b/resources/views/front/feed.blade.php
@@ -1,0 +1,23 @@
+@php echo '<?xml version="1.0" encoding="UTF-8"?>'; @endphp
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ $settings->site_title ?? config('app.name') }}</title>
+        <link>{{ route('home') }}</link>
+        <description>{{ $settings->site_meta_description ?? $settings->site_description ?? config('app.name') . ' latest articles' }}</description>
+        <language>{{ str_replace('_', '-', app()->getLocale()) }}</language>
+        <lastBuildDate>{{ optional($updated)->toRfc2822String() }}</lastBuildDate>
+        <atom:link href="{{ route('feed') }}" rel="self" type="application/rss+xml" />
+        @foreach($posts as $post)
+            <item>
+                <title><![CDATA[{{ $post->title }}]]></title>
+                <link>{{ route('posts.show', $post) }}</link>
+                <guid isPermaLink="true">{{ route('posts.show', $post) }}</guid>
+                <pubDate>{{ optional($post->created_at)->toRfc2822String() }}</pubDate>
+                <description><![CDATA[{{ $post->meta_description ?? $post->excerpt }}]]></description>
+                @if($post->category)
+                    <category><![CDATA[{{ $post->category->name }}]]></category>
+                @endif
+            </item>
+        @endforeach
+    </channel>
+</rss>

--- a/resources/views/front/home.blade.php
+++ b/resources/views/front/home.blade.php
@@ -1,0 +1,79 @@
+@extends('layouts.front')
+
+@section('content')
+<section class="bg-white border-b border-slate-200">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div class="max-w-3xl">
+            <h1 class="text-3xl font-bold text-slate-900 sm:text-4xl">
+                {{ $seo['title'] ?? ($settings->site_title ?? config('app.name')) }}
+            </h1>
+            <p class="mt-4 text-lg text-slate-600">
+                {{ $seo['description'] ?? ($settings->site_meta_description ?? 'Stay informed with the latest stories and insights.') }}
+            </p>
+            @if(!empty($search))
+                <p class="mt-4 text-sm text-slate-500">Showing results for “{{ $search }}”. <a class="text-indigo-600 hover:text-indigo-700" href="{{ route('home') }}">Clear search</a></p>
+            @endif
+        </div>
+    </div>
+</section>
+
+<section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        @forelse ($posts as $post)
+            <article class="group flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+                @if ($post->thumbnail_url)
+                    <a href="{{ route('posts.show', $post) }}" class="relative block aspect-[16/9] overflow-hidden bg-slate-100">
+                        <img src="{{ $post->thumbnail_url }}" alt="{{ $post->title }}" class="h-full w-full object-cover transition duration-500 group-hover:scale-105">
+                    </a>
+                @endif
+                <div class="flex flex-1 flex-col p-6">
+                    <div class="flex items-center gap-2 text-xs uppercase tracking-wide text-indigo-600">
+                        @if($post->category)
+                            <span>{{ $post->category->name }}</span>
+                        @endif
+                        <span class="text-slate-400">•</span>
+                        <time datetime="{{ optional($post->created_at)->toDateString() }}" class="text-slate-500">{{ optional($post->created_at)->format('M d, Y') }}</time>
+                    </div>
+                    <h2 class="mt-3 text-xl font-semibold text-slate-900 group-hover:text-indigo-600">
+                        <a href="{{ route('posts.show', $post) }}">{{ $post->title }}</a>
+                    </h2>
+                    <p class="mt-3 text-sm text-slate-600 flex-1">{{ $post->excerpt }}</p>
+                    <div class="mt-6 flex items-center justify-between text-sm text-indigo-600">
+                        <a href="{{ route('posts.show', $post) }}" class="font-semibold hover:text-indigo-700">Read full story</a>
+                        @if($post->author)
+                            <span class="text-slate-500">By {{ $post->author->name }}</span>
+                        @endif
+                    </div>
+                </div>
+            </article>
+        @empty
+            <div class="col-span-full text-center">
+                <p class="text-lg font-medium text-slate-600">No articles found.</p>
+                <p class="mt-2 text-sm text-slate-500">Try adjusting your search or check back later for new stories.</p>
+            </div>
+        @endforelse
+    </div>
+
+    <div class="mt-12">
+        {{ $posts->links() }}
+    </div>
+</section>
+@endsection
+
+@push('meta')
+    @php
+        $webSiteSchema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'WebSite',
+            'name' => $settings->site_title ?? config('app.name'),
+            'url' => $seo['canonical'] ?? url('/'),
+        ];
+
+        $webSiteSchema['potentialAction'] = [
+            '@type' => 'SearchAction',
+            'target' => route('home') . '?search={search_term_string}',
+            'query-input' => 'required name=search_term_string',
+        ];
+    @endphp
+    <script type="application/ld+json">{!! json_encode($webSiteSchema, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) !!}</script>
+@endpush

--- a/resources/views/front/post.blade.php
+++ b/resources/views/front/post.blade.php
@@ -1,0 +1,150 @@
+@extends('layouts.front')
+
+@section('content')
+<article class="bg-white">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <nav class="text-sm text-slate-500" aria-label="Breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+            <ol class="flex flex-wrap items-center gap-1">
+                <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                    <a href="{{ route('home') }}" itemprop="item" class="hover:text-indigo-600">
+                        <span itemprop="name">Home</span>
+                    </a>
+                    <meta itemprop="position" content="1" />
+                </li>
+                @if($post->category)
+                    <span aria-hidden="true">/</span>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">{{ $post->category->name }}</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                    <span aria-hidden="true">/</span>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">{{ $post->title }}</span>
+                        <meta itemprop="position" content="3" />
+                    </li>
+                @else
+                    <span aria-hidden="true">/</span>
+                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                        <span itemprop="name">{{ $post->title }}</span>
+                        <meta itemprop="position" content="2" />
+                    </li>
+                @endif
+            </ol>
+        </nav>
+
+        <header class="mt-6">
+            <h1 class="text-3xl font-bold text-slate-900 sm:text-4xl">{{ $post->title }}</h1>
+            <div class="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-slate-500">
+                @if($post->author)
+                    <span>By <span class="font-medium text-slate-700">{{ $post->author->name }}</span></span>
+                @endif
+                <span aria-hidden="true">•</span>
+                <time datetime="{{ optional($post->created_at)->toDateString() }}">Published {{ optional($post->created_at)->format('F d, Y') }}</time>
+                @if($post->updated_at && $post->updated_at->ne($post->created_at))
+                    <span aria-hidden="true">•</span>
+                    <time datetime="{{ optional($post->updated_at)->toDateString() }}">Updated {{ optional($post->updated_at)->format('F d, Y') }}</time>
+                @endif
+            </div>
+        </header>
+
+        @if ($post->thumbnail_url)
+            <figure class="mt-8">
+                <img src="{{ $post->thumbnail_url }}" alt="{{ $post->title }}" class="w-full rounded-xl object-cover shadow-lg">
+            </figure>
+        @endif
+
+        <div class="prose prose-slate max-w-none mt-8">
+            {!! $post->description !!}
+        </div>
+
+        <section class="mt-12 rounded-xl border border-slate-200 bg-slate-50 p-6">
+            <h2 class="text-lg font-semibold text-slate-800">Enjoyed this story?</h2>
+            <p class="mt-2 text-sm text-slate-600">Share it with your network to help others discover insightful updates.</p>
+            <div class="mt-4 flex flex-wrap gap-3">
+                <a href="https://www.facebook.com/sharer/sharer.php?u={{ urlencode($seo['canonical']) }}" class="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700" target="_blank" rel="noopener">
+                    Share on Facebook
+                </a>
+                <a href="https://twitter.com/intent/tweet?url={{ urlencode($seo['canonical']) }}&text={{ urlencode($post->title) }}" class="inline-flex items-center rounded-lg bg-sky-500 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-600" target="_blank" rel="noopener">
+                    Share on X
+                </a>
+                <a href="https://www.linkedin.com/shareArticle?url={{ urlencode($seo['canonical']) }}&title={{ urlencode($post->title) }}" class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700" target="_blank" rel="noopener">
+                    Share on LinkedIn
+                </a>
+            </div>
+        </section>
+    </div>
+</article>
+@endsection
+
+@push('meta')
+    @php
+        $logoPath = $settings?->site_logo;
+        $logoUrl = $logoPath
+            ? (\Illuminate\Support\Str::startsWith($logoPath, ['http://', 'https://'])
+                ? $logoPath
+                : \Illuminate\Support\Facades\Storage::url($logoPath))
+            : asset('favicon.ico');
+
+        $articleSchema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'NewsArticle',
+            'headline' => $post->title,
+            'datePublished' => $seo['published_time'] ?? optional($post->created_at)->toIso8601String(),
+            'dateModified' => $seo['modified_time'] ?? optional($post->updated_at ?? $post->created_at)->toIso8601String(),
+            'author' => $post->author ? [
+                '@type' => 'Person',
+                'name' => $post->author->name,
+            ] : null,
+            'publisher' => [
+                '@type' => 'Organization',
+                'name' => $settings->site_title ?? config('app.name'),
+                'logo' => [
+                    '@type' => 'ImageObject',
+                    'url' => $logoUrl,
+                ],
+            ],
+            'image' => array_filter([$seo['image'] ?? null]),
+            'mainEntityOfPage' => $seo['canonical'] ?? route('posts.show', $post),
+            'articleSection' => $post->category?->name,
+            'description' => $seo['description'] ?? $post->excerpt,
+        ];
+
+        $articleSchema = array_filter($articleSchema, fn ($value) => !is_null($value));
+
+        $breadcrumbSchema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => [
+                [
+                    '@type' => 'ListItem',
+                    'position' => 1,
+                    'name' => 'Home',
+                    'item' => route('home'),
+                ],
+            ],
+        ];
+
+        if ($post->category) {
+            $breadcrumbSchema['itemListElement'][] = [
+                '@type' => 'ListItem',
+                'position' => 2,
+                'name' => $post->category->name,
+            ];
+            $breadcrumbSchema['itemListElement'][] = [
+                '@type' => 'ListItem',
+                'position' => 3,
+                'name' => $post->title,
+                'item' => $seo['canonical'] ?? route('posts.show', $post),
+            ];
+        } else {
+            $breadcrumbSchema['itemListElement'][] = [
+                '@type' => 'ListItem',
+                'position' => 2,
+                'name' => $post->title,
+                'item' => $seo['canonical'] ?? route('posts.show', $post),
+            ];
+        }
+    @endphp
+    <script type="application/ld+json">{!! json_encode($articleSchema, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) !!}</script>
+    <script type="application/ld+json">{!! json_encode($breadcrumbSchema, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) !!}</script>
+@endpush

--- a/resources/views/front/sitemap.blade.php
+++ b/resources/views/front/sitemap.blade.php
@@ -1,0 +1,17 @@
+@php echo '<?xml version="1.0" encoding="UTF-8"?>'; @endphp
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>{{ route('home') }}</loc>
+        <lastmod>{{ optional($lastUpdated)->tz('UTC')->toAtomString() }}</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>1.0</priority>
+    </url>
+    @foreach($posts as $post)
+        <url>
+            <loc>{{ route('posts.show', $post) }}</loc>
+            <lastmod>{{ optional($post->updated_at ?? $post->created_at)->tz('UTC')->toAtomString() }}</lastmod>
+            <changefreq>daily</changefreq>
+            <priority>0.8</priority>
+        </url>
+    @endforeach
+</urlset>

--- a/resources/views/layouts/front.blade.php
+++ b/resources/views/layouts/front.blade.php
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ $seo['title'] ?? ($settings->site_title ?? config('app.name')) }}</title>
+    <meta name="description" content="{{ $seo['description'] ?? '' }}">
+    @if(!empty($seo['keywords']))
+        <meta name="keywords" content="{{ $seo['keywords'] }}">
+    @endif
+    <meta name="robots" content="{{ ($seo['indexable'] ?? true) ? 'index,follow' : 'noindex,nofollow' }}">
+    <link rel="canonical" href="{{ $seo['canonical'] ?? url()->current() }}">
+
+    <meta property="og:type" content="{{ $seo['type'] ?? 'website' }}">
+    <meta property="og:title" content="{{ $seo['title'] ?? '' }}">
+    <meta property="og:description" content="{{ $seo['description'] ?? '' }}">
+    <meta property="og:url" content="{{ $seo['canonical'] ?? url()->current() }}">
+    <meta property="og:site_name" content="{{ $settings->site_title ?? config('app.name') }}">
+    @if(!empty($seo['image']))
+        <meta property="og:image" content="{{ $seo['image'] }}">
+    @endif
+    @if(!empty($seo['published_time']))
+        <meta property="article:published_time" content="{{ $seo['published_time'] }}">
+    @endif
+    @if(!empty($seo['modified_time']))
+        <meta property="article:modified_time" content="{{ $seo['modified_time'] }}">
+    @endif
+
+    <meta name="twitter:card" content="{{ !empty($seo['image']) ? 'summary_large_image' : 'summary' }}">
+    <meta name="twitter:title" content="{{ $seo['title'] ?? '' }}">
+    <meta name="twitter:description" content="{{ $seo['description'] ?? '' }}">
+    @if(!empty($seo['image']))
+        <meta name="twitter:image" content="{{ $seo['image'] }}">
+    @endif
+
+    <link rel="alternate" type="application/rss+xml" title="{{ $settings->site_title ?? config('app.name') }} RSS Feed" href="{{ route('feed') }}">
+
+    @stack('meta')
+
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="font-sans antialiased bg-slate-100 text-slate-900">
+<a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 bg-slate-900 text-white px-4 py-2 rounded-md">Skip to content</a>
+<header class="bg-white shadow-sm">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+            <a href="{{ route('home') }}" class="text-2xl font-bold text-slate-900 hover:text-indigo-600 transition-colors">
+                {{ $settings->site_title ?? config('app.name') }}
+            </a>
+            @if(!empty($settings?->site_description))
+                <p class="mt-1 text-sm text-slate-500">{{ $settings->site_description }}</p>
+            @endif
+        </div>
+        <form action="{{ route('home') }}" method="get" class="w-full md:w-auto md:min-w-[320px]">
+            <label for="search" class="sr-only">Search</label>
+            <div class="relative">
+                <input id="search" name="search" type="search" value="{{ request('search') }}" placeholder="Search articles..." class="w-full rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm focus:border-indigo-500 focus:bg-white focus:outline-none">
+                <button type="submit" class="absolute inset-y-0 right-1 my-1 px-3 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">Search</button>
+            </div>
+        </form>
+    </div>
+</header>
+<main id="main" class="min-h-screen">
+    @yield('content')
+</main>
+<footer class="bg-slate-900 text-slate-200 mt-16">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 grid gap-8 md:grid-cols-3">
+        <div>
+            <h2 class="text-lg font-semibold">About</h2>
+            <p class="mt-2 text-sm leading-relaxed text-slate-400">
+                {{ $settings?->site_meta_description ?? 'Latest stories, updates, and breaking news from our editorial desk.' }}
+            </p>
+        </div>
+        <div>
+            <h2 class="text-lg font-semibold">Contact</h2>
+            <ul class="mt-2 space-y-1 text-sm text-slate-400">
+                @if(!empty($settings?->site_email))
+                    <li>Email: <a href="mailto:{{ $settings->site_email }}" class="text-slate-200 hover:text-white">{{ $settings->site_email }}</a></li>
+                @endif
+                @if(!empty($settings?->site_phone))
+                    <li>Phone: <a href="tel:{{ preg_replace('/[^\d+]/', '', $settings->site_phone) }}" class="text-slate-200 hover:text-white">{{ $settings->site_phone }}</a></li>
+                @endif
+            </ul>
+        </div>
+        <div>
+            <h2 class="text-lg font-semibold">Stay Updated</h2>
+            <p class="mt-2 text-sm text-slate-400">Subscribe to our RSS feed for instant updates.</p>
+            <a href="{{ route('feed') }}" class="mt-3 inline-flex items-center rounded-md bg-indigo-500 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-600">View RSS Feed</a>
+        </div>
+    </div>
+    <div class="border-t border-slate-800">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 text-sm text-slate-500 flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+            <span>&copy; {{ now()->year }} {{ $settings->site_title ?? config('app.name') }}. All rights reserved.</span>
+            @if(!empty($settings?->site_copyright))
+                <span>{{ $settings->site_copyright }}</span>
+            @endif
+        </div>
+    </div>
+</footer>
+@stack('scripts')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,14 +5,19 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Admin\CategoryController;
-use App\Http\Controllers\Admin\PostController;
+use App\Http\Controllers\Admin\PostController as AdminPostController;
 use App\Http\Controllers\Admin\SubCategoryController;
 use App\Http\Controllers\Admin\UserManagementController;
 use App\Http\Controllers\Admin\RoleController;
+use App\Http\Controllers\Frontend\FeedController;
+use App\Http\Controllers\Frontend\HomeController as FrontHomeController;
+use App\Http\Controllers\Frontend\PostController as FrontPostController;
+use App\Http\Controllers\Frontend\SitemapController;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', [FrontHomeController::class, 'index'])->name('home');
+Route::get('/news/{post:slug}', [FrontPostController::class, 'show'])->name('posts.show');
+Route::get('/sitemap.xml', SitemapController::class)->name('sitemap');
+Route::get('/feed', FeedController::class)->name('feed');
 
 
 //Testing route
@@ -43,7 +48,7 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
         Route::resource('categories', CategoryController::class)->except(['show']);
         Route::resource('subcategories', SubCategoryController::class)->except(['show']);
-        Route::resource('posts', PostController::class)->only(['index', 'create', 'edit']);
+        Route::resource('posts', AdminPostController::class)->only(['index', 'create', 'edit']);
 
        Route::resource('roles', RoleController::class);
        Route::resource('permissions', PermissionController::class);


### PR DESCRIPTION
## Summary
- add dedicated frontend controllers and Blade templates to deliver SEO-optimized blog and article pages
- generate structured metadata, sitemap.xml, RSS feed, and improved robots.txt for better discoverability
- enhance the Post model with slug routing plus thumbnail and excerpt accessors for cleaner views

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dfa40a5e68832e926f25f4bfb39c38