### PR TITLE
Add admin poll management with activation controls

### DIFF
--- a/app/Http/Controllers/Admin/PollController.php
+++ b/app/Http/Controllers/Admin/PollController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Poll;
+use Illuminate\Support\Facades\Gate;
+
+class PollController extends Controller
+{
+    public function index()
+    {
+        Gate::authorize('poll.view');
+
+        return view('back.pages.polls.index', [
+            'pageTitle' => 'Polls',
+        ]);
+    }
+
+    public function create()
+    {
+        Gate::authorize('poll.create');
+
+        return view('back.pages.polls.create', [
+            'pageTitle' => 'Create Poll',
+        ]);
+    }
+
+    public function edit(Poll $poll)
+    {
+        Gate::authorize('poll.edit');
+
+        return view('back.pages.polls.edit', [
+            'pageTitle' => 'Edit Poll',
+            'poll' => $poll,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Frontend/PollController.php
+++ b/app/Http/Controllers/Frontend/PollController.php
@@ -18,7 +18,16 @@ class PollController extends Controller
     public function index(): View
     {
         $settings = $this->settings();
-        $polls = Poll::query()->latest('poll_date')->paginate(10);
+        $polls = Poll::query()
+            ->orderByDesc('poll_date')
+            ->orderByDesc('created_at')
+            ->paginate(10);
+
+        $activePoll = Poll::query()
+            ->where('is_active', true)
+            ->orderByDesc('poll_date')
+            ->orderByDesc('created_at')
+            ->first();
 
         $seo = [
             'title' => 'Opinion Polls | ' . ($settings?->site_title ?? config('app.name')),
@@ -28,7 +37,7 @@ class PollController extends Controller
             'indexable' => true,
         ];
 
-        return view('front.polls.index', compact('polls', 'seo', 'settings'));
+        return view('front.polls.index', compact('polls', 'seo', 'settings', 'activePoll'));
     }
 
     /**
@@ -45,6 +54,10 @@ class PollController extends Controller
             'no' => 'no_votes',
             'no_opinion' => 'no_opinion_votes',
         };
+
+        if (! $poll->is_active) {
+            return back()->with('status', 'এই জরিপের ভোট গ্রহণ বন্ধ রয়েছে।');
+        }
 
         $poll->increment($column);
 

--- a/app/Livewire/Admin/PollForm.php
+++ b/app/Livewire/Admin/PollForm.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Poll;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class PollForm extends Component
+{
+    use WithFileUploads;
+
+    public ?Poll $poll = null;
+
+    public string $question = '';
+    public ?string $poll_date = null;
+    public ?string $source_url = null;
+    public bool $is_active = true;
+    public string $yes_votes = '0';
+    public string $no_votes = '0';
+    public string $no_opinion_votes = '0';
+    public $image;
+    public ?string $existingImage = null;
+
+    public function mount(?Poll $poll = null): void
+    {
+        $this->poll = $poll;
+
+        if ($poll) {
+            $this->question = $poll->question;
+            $this->poll_date = optional($poll->poll_date)->format('Y-m-d');
+            $this->source_url = $poll->source_url;
+            $this->is_active = (bool) $poll->is_active;
+            $this->yes_votes = (string) $poll->yes_votes;
+            $this->no_votes = (string) $poll->no_votes;
+            $this->no_opinion_votes = (string) $poll->no_opinion_votes;
+            $this->existingImage = $poll->image;
+        }
+    }
+
+    public function removeExistingImage(): void
+    {
+        if (! $this->existingImage) {
+            return;
+        }
+
+        Gate::authorize('poll.edit');
+
+        Storage::disk('public')->delete($this->existingImage);
+
+        if ($this->poll) {
+            $this->poll->update(['image' => null]);
+        }
+
+        $this->existingImage = null;
+
+        $this->dispatch('showToastr', type: 'success', message: 'Poll image removed successfully.');
+    }
+
+    public function save()
+    {
+        if ($this->poll) {
+            Gate::authorize('poll.edit');
+        } else {
+            Gate::authorize('poll.create');
+        }
+
+        $data = $this->validate($this->rules());
+
+        $data['question'] = trim($data['question']);
+        $this->question = $data['question'];
+        $data['poll_date'] = $data['poll_date'] ?: null;
+        $data['source_url'] = $data['source_url'] ? trim($data['source_url']) : null;
+        $data['is_active'] = $this->is_active;
+        $data['yes_votes'] = (int) ($data['yes_votes'] ?? 0);
+        $data['no_votes'] = (int) ($data['no_votes'] ?? 0);
+        $data['no_opinion_votes'] = (int) ($data['no_opinion_votes'] ?? 0);
+
+        if ($this->image) {
+            if ($this->existingImage) {
+                Storage::disk('public')->delete($this->existingImage);
+            }
+
+            $data['image'] = $this->image->store('polls', 'public');
+        } else {
+            unset($data['image']);
+        }
+
+        if ($this->poll && $this->poll->exists) {
+            $this->poll->update($data);
+            $message = 'Poll updated successfully.';
+        } else {
+            $this->poll = Poll::create($data);
+            $message = 'Poll created successfully.';
+        }
+
+        $this->dispatch('showToastr', type: 'success', message: $message);
+
+        return redirect()->route('admin.polls.index')->with('success', $message);
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'question' => ['required', 'string', 'max:255'],
+            'poll_date' => ['nullable', 'date'],
+            'source_url' => ['nullable', 'url'],
+            'is_active' => ['boolean'],
+            'yes_votes' => ['nullable', 'integer', 'min:0'],
+            'no_votes' => ['nullable', 'integer', 'min:0'],
+            'no_opinion_votes' => ['nullable', 'integer', 'min:0'],
+            'image' => ['nullable', 'image', 'max:4096'],
+        ];
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.poll-form');
+    }
+}

--- a/app/Livewire/Admin/PollsTable.php
+++ b/app/Livewire/Admin/PollsTable.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Poll;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class PollsTable extends Component
+{
+    use WithPagination;
+
+    protected $paginationTheme = 'bootstrap';
+
+    public string $search = '';
+    public string $status = 'all';
+
+    public function updatedSearch(): void
+    {
+        $this->search = trim($this->search);
+    }
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedStatus(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggleStatus(int $pollId): void
+    {
+        Gate::authorize('poll.edit');
+
+        $poll = Poll::findOrFail($pollId);
+        $poll->update(['is_active' => ! $poll->is_active]);
+
+        $message = $poll->is_active
+            ? 'Poll reopened for voting.'
+            : 'Poll voting has been closed.';
+
+        $this->dispatch('showToastr', type: 'success', message: $message);
+    }
+
+    public function deletePoll(int $pollId): void
+    {
+        Gate::authorize('poll.delete');
+
+        $poll = Poll::findOrFail($pollId);
+
+        if ($poll->image) {
+            Storage::disk('public')->delete($poll->image);
+        }
+
+        $poll->delete();
+
+        $this->dispatch('showToastr', type: 'success', message: 'Poll removed successfully.');
+
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $polls = Poll::query()
+            ->when($this->search !== '', function ($query) {
+                $search = '%'.$this->search.'%';
+
+                $query->where(function ($nested) use ($search) {
+                    $nested->where('question', 'like', $search)
+                        ->orWhere('source_url', 'like', $search);
+                });
+            })
+            ->when($this->status === 'active', fn ($query) => $query->where('is_active', true))
+            ->when($this->status === 'closed', fn ($query) => $query->where('is_active', false))
+            ->orderByDesc('poll_date')
+            ->orderByDesc('created_at')
+            ->paginate(10);
+
+        return view('livewire.admin.polls-table', [
+            'polls' => $polls,
+        ]);
+    }
+}

--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -22,6 +22,7 @@ class Poll extends Model
         'image',
         'source_url',
         'poll_date',
+        'is_active',
         'yes_votes',
         'no_votes',
         'no_opinion_votes',
@@ -34,6 +35,7 @@ class Poll extends Model
      */
     protected $casts = [
         'poll_date' => 'date',
+        'is_active' => 'bool',
     ];
 
     /**

--- a/database/migrations/2025_10_07_000001_add_is_active_to_polls_table.php
+++ b/database/migrations/2025_10_07_000001_add_is_active_to_polls_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('polls', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('poll_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('polls', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/database/seeders/PollSeeder.php
+++ b/database/seeders/PollSeeder.php
@@ -21,6 +21,7 @@ class PollSeeder extends Seeder
             [
                 'image' => 'polls/1756214840-68adb638672b3.jpg',
                 'source_url' => 'https://bhorerkagoj.com/poll/152',
+                'is_active' => true,
                 'yes_votes' => 356,
                 'no_votes' => 704,
                 'no_opinion_votes' => 40,

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -54,6 +54,15 @@ class RolePermissionSeeder extends Seeder
                     'post.edit',
                     'post.delete',
                 ]
+            ],
+            [
+                'group_name' => 'Polls',
+                'permissions' => [
+                    'poll.view',
+                    'poll.create',
+                    'poll.edit',
+                    'poll.delete',
+                ]
             ]
         ];
         foreach ($permissionsAll as $permGroup) {

--- a/resources/views/back/pages/polls/create.blade.php
+++ b/resources/views/back/pages/polls/create.blade.php
@@ -1,0 +1,14 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Create Poll')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <h1 class="page-title mb-0">Create Poll</h1>
+            <a href="{{ route('admin.polls.index') }}" class="btn btn-link">&larr; Back to polls</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <livewire:admin.poll-form />
+    </div>
+@endsection

--- a/resources/views/back/pages/polls/edit.blade.php
+++ b/resources/views/back/pages/polls/edit.blade.php
@@ -1,0 +1,14 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Edit Poll')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex justify-content-between align-items-center">
+            <h1 class="page-title mb-0">Edit Poll</h1>
+            <a href="{{ route('admin.polls.index') }}" class="btn btn-link">&larr; Back to polls</a>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <livewire:admin.poll-form :poll="$poll" />
+    </div>
+@endsection

--- a/resources/views/back/pages/polls/index.blade.php
+++ b/resources/views/back/pages/polls/index.blade.php
@@ -1,0 +1,23 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Polls')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+            <div>
+                <h1 class="page-title">Opinion Polls</h1>
+                <p class="text-muted mb-0">Create, update, or close opinion polls directly from the dashboard.</p>
+            </div>
+            @can('poll.create')
+                <a href="{{ route('admin.polls.create') }}" class="btn btn-primary">Create New Poll</a>
+            @endcan
+        </div>
+    </header>
+
+    <div class="page-section">
+        @if (session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+
+        <livewire:admin.polls-table />
+    </div>
+@endsection

--- a/resources/views/back/partials/sidebar.blade.php
+++ b/resources/views/back/partials/sidebar.blade.php
@@ -30,7 +30,7 @@
 
 
                     <li class="menu-header">Blog Management</li>
-                    <li class="menu-item has-child {{ request()->routeIs('admin.posts.*') || request()->routeIs('admin.categories.*') || request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
+                    <li class="menu-item has-child {{ request()->routeIs('admin.posts.*') || request()->routeIs('admin.polls.*') || request()->routeIs('admin.categories.*') || request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
                         <a href="#" class="menu-link"><span class="menu-icon oi oi-document"></span> <span class="menu-text">Posts</span></a>
                         <ul class="menu">
                             @can('post.view')
@@ -48,6 +48,12 @@
                             @can('subcategory.view')
                                 <li class="menu-item {{ request()->routeIs('admin.subcategories.*') ? 'has-active' : '' }}">
                                     <a href="{{ route('admin.subcategories.index') }}" class="menu-link"><span class="menu-text">Sub Categories</span></a>
+                                </li>
+                            @endcan
+
+                            @can('poll.view')
+                                <li class="menu-item {{ request()->routeIs('admin.polls.*') ? 'has-active' : '' }}">
+                                    <a href="{{ route('admin.polls.index') }}" class="menu-link"><span class="menu-text">Opinion Polls</span></a>
                                 </li>
                             @endcan
 

--- a/resources/views/front/polls/index.blade.php
+++ b/resources/views/front/polls/index.blade.php
@@ -19,43 +19,55 @@
             </div>
         @endif
 
-        @php($latestPoll = $polls->getCollection()->first())
+        @php($latestPoll = $polls->first())
+        @php($displayPoll = $activePoll ?? $latestPoll)
 
-        @if($latestPoll)
+        @if($displayPoll)
             <div class="grid gap-8 lg:grid-cols-[2fr,3fr] items-start">
                 <div class="rounded-xl border border-slate-200 bg-white shadow-sm p-6">
-                    <h2 class="text-2xl font-semibold text-slate-900">{{ $latestPoll->question }}</h2>
-                    <p class="mt-2 text-sm text-slate-500">{{ optional($latestPoll->poll_date)->format('F d, Y') }}</p>
+                    <h2 class="text-2xl font-semibold text-slate-900">{{ $displayPoll->question }}</h2>
+                    <p class="mt-2 text-sm text-slate-500">{{ optional($displayPoll->poll_date)->format('F d, Y') }}</p>
+                    @if($displayPoll->source_url)
+                        <p class="mt-1 text-xs">
+                            <a href="{{ $displayPoll->source_url }}" target="_blank" rel="noopener" class="text-indigo-600 hover:text-indigo-700">সূত্র দেখুন</a>
+                        </p>
+                    @endif
 
-                    <form action="{{ route('polls.vote', $latestPoll) }}" method="POST" class="mt-6 space-y-3">
-                        @csrf
-                        <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
-                            <div class="flex items-center gap-3">
-                                <input type="radio" name="option" value="yes" class="h-4 w-4 text-indigo-600" required>
-                                <span class="font-medium text-slate-800">হ্যাঁ ({{ $latestPoll->yes_vote_bangla }} ভোট)</span>
-                            </div>
-                            <span class="text-sm text-slate-500">{{ $latestPoll->yes_vote_percent_bangla }}%</span>
-                        </label>
-                        <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
-                            <div class="flex items-center gap-3">
-                                <input type="radio" name="option" value="no" class="h-4 w-4 text-indigo-600" required>
-                                <span class="font-medium text-slate-800">না ({{ $latestPoll->no_vote_bangla }} ভোট)</span>
-                            </div>
-                            <span class="text-sm text-slate-500">{{ $latestPoll->no_vote_percent_bangla }}%</span>
-                        </label>
-                        <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
-                            <div class="flex items-center gap-3">
-                                <input type="radio" name="option" value="no_opinion" class="h-4 w-4 text-indigo-600" required>
-                                <span class="font-medium text-slate-800">মতামত নেই ({{ $latestPoll->no_opinion_bangla }} ভোট)</span>
-                            </div>
-                            <span class="text-sm text-slate-500">{{ $latestPoll->no_opinion_vote_percent_bangla }}%</span>
-                        </label>
-                        <button type="submit" class="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700">
-                            এখনই ভোট দিন
-                        </button>
-                    </form>
+                    @if($activePoll && $displayPoll->id === $activePoll->id)
+                        <form action="{{ route('polls.vote', $activePoll) }}" method="POST" class="mt-6 space-y-3">
+                            @csrf
+                            <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
+                                <div class="flex items-center gap-3">
+                                    <input type="radio" name="option" value="yes" class="h-4 w-4 text-indigo-600" required>
+                                    <span class="font-medium text-slate-800">হ্যাঁ ({{ $activePoll->yes_vote_bangla }} ভোট)</span>
+                                </div>
+                                <span class="text-sm text-slate-500">{{ $activePoll->yes_vote_percent_bangla }}%</span>
+                            </label>
+                            <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
+                                <div class="flex items-center gap-3">
+                                    <input type="radio" name="option" value="no" class="h-4 w-4 text-indigo-600" required>
+                                    <span class="font-medium text-slate-800">না ({{ $activePoll->no_vote_bangla }} ভোট)</span>
+                                </div>
+                                <span class="text-sm text-slate-500">{{ $activePoll->no_vote_percent_bangla }}%</span>
+                            </label>
+                            <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
+                                <div class="flex items-center gap-3">
+                                    <input type="radio" name="option" value="no_opinion" class="h-4 w-4 text-indigo-600" required>
+                                    <span class="font-medium text-slate-800">মতামত নেই ({{ $activePoll->no_opinion_bangla }} ভোট)</span>
+                                </div>
+                                <span class="text-sm text-slate-500">{{ $activePoll->no_opinion_vote_percent_bangla }}%</span>
+                            </label>
+                            <button type="submit" class="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700">
+                                এখনই ভোট দিন
+                            </button>
+                        </form>
+                    @else
+                        <div class="mt-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                            এই জরিপের ভোট গ্রহণ বন্ধ রয়েছে। ফলাফল নিচে দেখুন।
+                        </div>
+                    @endif
 
-                    <p class="mt-4 text-xs text-slate-500">মোট ভোট: {{ $latestPoll->total_vote_bangla }} | প্রকাশিত: {{ $latestPoll->poll_date_bangla }}</p>
+                    <p class="mt-4 text-xs text-slate-500">মোট ভোট: {{ $displayPoll->total_vote_bangla }} | প্রকাশিত: {{ $displayPoll->poll_date_bangla }}</p>
                 </div>
 
                 <div class="rounded-xl border border-slate-200 bg-white shadow-sm p-6">
@@ -64,32 +76,36 @@
                         <li>
                             <div class="flex items-center justify-between text-sm font-medium text-slate-700">
                                 <span>হ্যাঁ</span>
-                                <span>{{ $latestPoll->yes_vote_percent }}%</span>
+                                <span>{{ $displayPoll->yes_vote_percent }}%</span>
                             </div>
                             <div class="mt-2 h-2 w-full rounded-full bg-slate-200">
-                                <div class="h-full rounded-full bg-emerald-500" style="width: {{ $latestPoll->yes_vote_percent }}%"></div>
+                                <div class="h-full rounded-full bg-emerald-500" style="width: {{ $displayPoll->yes_vote_percent }}%"></div>
                             </div>
                         </li>
                         <li>
                             <div class="flex items-center justify-between text-sm font-medium text-slate-700">
                                 <span>না</span>
-                                <span>{{ $latestPoll->no_vote_percent }}%</span>
+                                <span>{{ $displayPoll->no_vote_percent }}%</span>
                             </div>
                             <div class="mt-2 h-2 w-full rounded-full bg-slate-200">
-                                <div class="h-full rounded-full bg-rose-500" style="width: {{ $latestPoll->no_vote_percent }}%"></div>
+                                <div class="h-full rounded-full bg-rose-500" style="width: {{ $displayPoll->no_vote_percent }}%"></div>
                             </div>
                         </li>
                         <li>
                             <div class="flex items-center justify-between text-sm font-medium text-slate-700">
                                 <span>মতামত নেই</span>
-                                <span>{{ $latestPoll->no_opinion_vote_percent }}%</span>
+                                <span>{{ $displayPoll->no_opinion_vote_percent }}%</span>
                             </div>
                             <div class="mt-2 h-2 w-full rounded-full bg-slate-200">
-                                <div class="h-full rounded-full bg-amber-500" style="width: {{ $latestPoll->no_opinion_vote_percent }}%"></div>
+                                <div class="h-full rounded-full bg-amber-500" style="width: {{ $displayPoll->no_opinion_vote_percent }}%"></div>
                             </div>
                         </li>
                     </ul>
                 </div>
+            </div>
+        @else
+            <div class="rounded-xl border border-slate-200 bg-white px-6 py-8 text-center text-slate-600">
+                বর্তমানে কোনো জরিপ উপলব্ধ নেই।
             </div>
         @endif
 
@@ -101,6 +117,7 @@
                             <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">ছবি</th>
                             <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">প্রশ্ন</th>
                             <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">তারিখ</th>
+                            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">স্থিতি</th>
                             <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">মোট ভোট</th>
                             <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">হ্যাঁ</th>
                             <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500">না</th>
@@ -126,6 +143,11 @@
                                     @endif
                                 </td>
                                 <td class="whitespace-nowrap px-4 py-3 text-sm text-slate-600">{{ $poll->poll_date_bangla }}</td>
+                                <td class="whitespace-nowrap px-4 py-3 text-sm">
+                                    <span class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold {{ $poll->is_active ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600' }}">
+                                        {{ $poll->is_active ? 'সক্রিয়' : 'বন্ধ' }}
+                                    </span>
+                                </td>
                                 <td class="whitespace-nowrap px-4 py-3 text-sm text-slate-600">
                                     <div>{{ $poll->total_votes }} ({{ $poll->total_vote_bangla }})</div>
                                 </td>
@@ -144,7 +166,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="7" class="px-4 py-6 text-center text-sm text-slate-500">কোনো জরিপ পাওয়া যায়নি।</td>
+                                <td colspan="8" class="px-4 py-6 text-center text-sm text-slate-500">কোনো জরিপ পাওয়া যায়নি।</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/livewire/admin/poll-form.blade.php
+++ b/resources/views/livewire/admin/poll-form.blade.php
@@ -1,0 +1,92 @@
+<div>
+    <form wire:submit.prevent="save" class="card card-fluid">
+        <div class="card-body">
+            <div class="form-group">
+                <label for="pollQuestion">Poll question <span class="text-danger">*</span></label>
+                <input type="text" id="pollQuestion" class="form-control @error('question') is-invalid @enderror" wire:model.defer="question" placeholder="What question are you asking?">
+                @error('question')
+                    <div class="invalid-feedback">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="form-row">
+                <div class="form-group col-md-4">
+                    <label for="pollDate">Poll date</label>
+                    <input type="date" id="pollDate" class="form-control @error('poll_date') is-invalid @enderror" wire:model.defer="poll_date">
+                    @error('poll_date')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="form-group col-md-8">
+                    <label for="pollSource">Source URL</label>
+                    <input type="url" id="pollSource" class="form-control @error('source_url') is-invalid @enderror" wire:model.defer="source_url" placeholder="https://example.com/poll">
+                    @error('source_url')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div class="custom-control custom-switch">
+                    <input type="checkbox" class="custom-control-input" id="pollIsActive" wire:model.defer="is_active">
+                    <label class="custom-control-label" for="pollIsActive">Poll is open for voting</label>
+                </div>
+                <small class="form-text text-muted">Turn this off to stop accepting votes instantly.</small>
+            </div>
+
+            <div class="card card-body border">
+                <h5 class="card-title">Initial vote counts</h5>
+                <div class="form-row">
+                    <div class="form-group col-md-4">
+                        <label for="yesVotes">Yes votes</label>
+                        <input type="number" min="0" id="yesVotes" class="form-control @error('yes_votes') is-invalid @enderror" wire:model.defer="yes_votes">
+                        @error('yes_votes')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="form-group col-md-4">
+                        <label for="noVotes">No votes</label>
+                        <input type="number" min="0" id="noVotes" class="form-control @error('no_votes') is-invalid @enderror" wire:model.defer="no_votes">
+                        @error('no_votes')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="form-group col-md-4">
+                        <label for="noOpinionVotes">No opinion votes</label>
+                        <input type="number" min="0" id="noOpinionVotes" class="form-control @error('no_opinion_votes') is-invalid @enderror" wire:model.defer="no_opinion_votes">
+                        @error('no_opinion_votes')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group mt-4">
+                <label for="pollImage">Poll image</label>
+                <input type="file" id="pollImage" class="form-control-file @error('image') is-invalid @enderror" wire:model="image" accept="image/*">
+                @error('image')
+                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                @enderror
+
+                <div class="mt-3">
+                    @if ($image)
+                        <p class="text-muted small mb-2">Preview:</p>
+                        <img src="{{ $image->temporaryUrl() }}" alt="Poll image preview" class="img-thumbnail" style="max-height: 180px;">
+                    @elseif ($existingImage)
+                        <p class="text-muted small mb-2">Current image:</p>
+                        <div class="d-flex align-items-center gap-3">
+                            <img src="{{ asset('storage/' . $existingImage) }}" alt="Poll image" class="img-thumbnail" style="max-height: 180px;">
+                            <button type="button" class="btn btn-sm btn-outline-danger" wire:click="removeExistingImage">Remove</button>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-end">
+            <a href="{{ route('admin.polls.index') }}" class="btn btn-link">Cancel</a>
+            <button type="submit" class="btn btn-primary ml-2">
+                {{ $poll ? 'Update Poll' : 'Create Poll' }}
+            </button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/admin/polls-table.blade.php
+++ b/resources/views/livewire/admin/polls-table.blade.php
@@ -1,0 +1,86 @@
+<div>
+    <div class="card card-fluid">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
+                <div class="w-100 w-lg-50">
+                    <input type="search" wire:model.live.debounce.500ms="search" class="form-control" placeholder="Search polls by question or source">
+                </div>
+                <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-2 w-100 w-lg-auto">
+                    <select wire:model.live="status" class="form-control w-100 w-lg-auto">
+                        <option value="all">All statuses</option>
+                        <option value="active">Active polls</option>
+                        <option value="closed">Closed polls</option>
+                    </select>
+                    <div class="text-muted small text-lg-right">
+                        Showing {{ $polls->firstItem() ?? 0 }} - {{ $polls->lastItem() ?? 0 }} of {{ $polls->total() }} polls
+                    </div>
+                </div>
+            </div>
+
+            <div class="table-responsive">
+                <table class="table align-middle">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Question</th>
+                            <th>Poll date</th>
+                            <th>Status</th>
+                            <th>Votes</th>
+                            <th>Updated</th>
+                            <th class="text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($polls as $poll)
+                            <tr wire:key="poll-{{ $poll->id }}">
+                                <td>{{ $loop->iteration + ($polls->currentPage() - 1) * $polls->perPage() }}</td>
+                                <td>
+                                    <div class="font-weight-bold">{{ $poll->question }}</div>
+                                    @if ($poll->source_url)
+                                        <div class="text-muted small">
+                                            <a href="{{ $poll->source_url }}" target="_blank" rel="noopener">{{ $poll->source_url }}</a>
+                                        </div>
+                                    @endif
+                                </td>
+                                <td>{{ optional($poll->poll_date)->format('d M, Y') ?? '—' }}</td>
+                                <td>
+                                    <span class="badge {{ $poll->is_active ? 'badge-success' : 'badge-secondary' }}">
+                                        {{ $poll->is_active ? 'Active' : 'Closed' }}
+                                    </span>
+                                </td>
+                                <td>
+                                    <div class="text-muted small">Total: {{ $poll->total_votes }}</div>
+                                    <div class="small">Yes: {{ $poll->yes_votes }} ({{ $poll->yes_vote_percent }}%)</div>
+                                    <div class="small">No: {{ $poll->no_votes }} ({{ $poll->no_vote_percent }}%)</div>
+                                    <div class="small">No opinion: {{ $poll->no_opinion_votes }} ({{ $poll->no_opinion_vote_percent }}%)</div>
+                                </td>
+                                <td>{{ $poll->updated_at?->format('d M, Y H:i') ?? '—' }}</td>
+                                <td class="text-right">
+                                    <div class="btn-group btn-group-sm" role="group">
+                                        @can('poll.edit')
+                                            <button type="button" class="btn {{ $poll->is_active ? 'btn-outline-warning' : 'btn-outline-success' }}" wire:click="toggleStatus({{ $poll->id }})">
+                                                {{ $poll->is_active ? 'Close voting' : 'Reopen voting' }}
+                                            </button>
+                                            <a href="{{ route('admin.polls.edit', $poll) }}" class="btn btn-outline-secondary">Edit</a>
+                                        @endcan
+                                        @can('poll.delete')
+                                            <button type="button" class="btn btn-outline-danger" wire:click="deletePoll({{ $poll->id }})" onclick="confirm('Are you sure you want to delete this poll?') || event.stopImmediatePropagation()">Delete</button>
+                                        @endcan
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center text-muted">No polls found.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            <div>
+                {{ $polls->links() }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\PostController as AdminPostController;
+use App\Http\Controllers\Admin\PollController as AdminPollController;
 use App\Http\Controllers\Admin\SubCategoryController;
 use App\Http\Controllers\Admin\UserManagementController;
 use App\Http\Controllers\Admin\RoleController;
@@ -52,6 +53,7 @@ Route::prefix('admin')->name('admin.')->group(function () {
         Route::resource('categories', CategoryController::class)->except(['show']);
         Route::resource('subcategories', SubCategoryController::class)->except(['show']);
         Route::resource('posts', AdminPostController::class)->only(['index', 'create', 'edit']);
+        Route::resource('polls', AdminPollController::class)->only(['index', 'create', 'edit']);
 
        Route::resource('roles', RoleController::class);
        Route::resource('permissions', PermissionController::class);


### PR DESCRIPTION
## Summary
- add an `is_active` flag to polls with model casting, database migration, and seeder defaults
- introduce admin poll management pages and Livewire components for creating, editing, toggling, and deleting polls
- update the public polls page to show active status, block closed poll voting, and surface status badges in the archive

## Testing
- `php artisan test` *(fails: composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dffcb34658832eb43a4d955f58cc1e