### PR TITLE
Allow poll form question property to accept null

### DIFF
--- a/app/Livewire/Admin/PollForm.php
+++ b/app/Livewire/Admin/PollForm.php
@@ -14,7 +14,7 @@ class PollForm extends Component
 
     public ?Poll $poll = null;
 
-    public string $question = '';
+    public ?string $question = '';
     public ?string $poll_date = null;
     public ?string $source_url = null;
     public bool $is_active = true;


### PR DESCRIPTION
## Summary
- allow the poll form's question property to accept null so Livewire can hydrate the component without type errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e004c38aa8832ebecf447054539136