### PR TITLE
Fix poll percentage calculation for null vote counts

### DIFF
--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -64,7 +64,7 @@ class Poll extends Model
     protected function totalVotes(): Attribute
     {
         return Attribute::get(function (): int {
-            return $this->yes_votes + $this->no_votes + $this->no_opinion_votes;
+            return (int) $this->yes_votes + (int) $this->no_votes + (int) $this->no_opinion_votes;
         });
     }
 
@@ -189,8 +189,10 @@ class Poll extends Model
     /**
      * Convert the supplied number into Bangla digits.
      */
-    protected function toBanglaDigits(int $number): string
+    protected function toBanglaDigits(int|string|null $number): string
     {
+        $number = $number ?? 0;
+
         $digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
         $banglaDigits = ['০', '১', '২', '৩', '৪', '৫', '৬', '৭', '৮', '৯'];
 
@@ -200,8 +202,10 @@ class Poll extends Model
     /**
      * Calculate the percentage value for the given vote count.
      */
-    protected function calculatePercentage(int $value): int
+    protected function calculatePercentage(?int $value): int
     {
+        $value = $value ?? 0;
+
         if ($this->total_votes === 0) {
             return 0;
         }


### PR DESCRIPTION
## Summary
- cast poll vote totals to integers so null counts are treated as zero
- allow Bangla digit conversion and percentage calculations to handle null values safely

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e006464b00832eaaee49644f2db5b8