### PR TITLE
Add interactive front-end poll voting

### DIFF
--- a/app/Http/Controllers/Frontend/PollController.php
+++ b/app/Http/Controllers/Frontend/PollController.php
@@ -56,10 +56,48 @@ class PollController extends Controller
         };
 
         if (! $poll->is_active) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => 'এই জরিপের ভোট গ্রহণ বন্ধ রয়েছে।',
+                ], 403);
+            }
+
             return back()->with('status', 'এই জরিপের ভোট গ্রহণ বন্ধ রয়েছে।');
         }
 
         $poll->increment($column);
+        $poll->refresh();
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'message' => 'আপনার ভোটের জন্য ধন্যবাদ!',
+                'poll' => [
+                    'id' => $poll->id,
+                    'totals' => [
+                        'total' => $poll->total_votes,
+                        'yes' => $poll->yes_votes,
+                        'no' => $poll->no_votes,
+                        'no_opinion' => $poll->no_opinion_votes,
+                    ],
+                    'totals_bangla' => [
+                        'total' => $poll->total_vote_bangla,
+                        'yes' => $poll->yes_vote_bangla,
+                        'no' => $poll->no_vote_bangla,
+                        'no_opinion' => $poll->no_opinion_bangla,
+                    ],
+                    'percentages' => [
+                        'yes' => $poll->yes_vote_percent,
+                        'no' => $poll->no_vote_percent,
+                        'no_opinion' => $poll->no_opinion_vote_percent,
+                    ],
+                    'percentages_bangla' => [
+                        'yes' => $poll->yes_vote_percent_bangla,
+                        'no' => $poll->no_vote_percent_bangla,
+                        'no_opinion' => $poll->no_opinion_vote_percent_bangla,
+                    ],
+                ],
+            ]);
+        }
 
         return back()->with('status', 'আপনার ভোটের জন্য ধন্যবাদ!');
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,215 @@ import "toastr";
 // পেজ প্রথমবার লোড হওয়ার জন্য
 document.addEventListener('DOMContentLoaded', () => {
     feather.replace();
+
+    const pollVoteForm = document.querySelector('#pollVoteForm');
+
+    if (pollVoteForm) {
+        const statusElement = document.querySelector('[data-poll-status]');
+        const submitButton = pollVoteForm.querySelector('button[type="submit"]');
+        const csrfToken = pollVoteForm.querySelector('input[name="_token"]').value;
+        const pollId = pollVoteForm.dataset.pollId;
+        const successMessage = pollVoteForm.dataset.successMessage || '';
+        const errorMessage = pollVoteForm.dataset.errorMessage || '';
+        const alreadyVotedMessage = pollVoteForm.dataset.alreadyVotedMessage || '';
+        const statusClasses = {
+            base: ['rounded-lg', 'border', 'px-4', 'py-3', 'text-sm'],
+            success: ['border-green-200', 'bg-green-50', 'text-green-700'],
+            error: ['border-red-200', 'bg-red-50', 'text-red-700'],
+        };
+
+        const countsBangla = {
+            yes: document.querySelector('[data-poll-count-bangla="yes"]'),
+            no: document.querySelector('[data-poll-count-bangla="no"]'),
+            no_opinion: document.querySelector('[data-poll-count-bangla="no_opinion"]'),
+        };
+
+        const percentagesBangla = {
+            yes: document.querySelector('[data-poll-percent-bangla="yes"]'),
+            no: document.querySelector('[data-poll-percent-bangla="no"]'),
+            no_opinion: document.querySelector('[data-poll-percent-bangla="no_opinion"]'),
+        };
+
+        const percentages = {
+            yes: document.querySelector('[data-poll-percent="yes"]'),
+            no: document.querySelector('[data-poll-percent="no"]'),
+            no_opinion: document.querySelector('[data-poll-percent="no_opinion"]'),
+        };
+
+        const progressBars = {
+            yes: document.querySelector('[data-poll-progress="yes"]'),
+            no: document.querySelector('[data-poll-progress="no"]'),
+            no_opinion: document.querySelector('[data-poll-progress="no_opinion"]'),
+        };
+
+        const totalBangla = document.querySelector('[data-poll-total-bangla]');
+        const pollInputs = pollVoteForm.querySelectorAll('input[name="option"]');
+
+        const showStatus = (message, type = 'success') => {
+            if (!statusElement) {
+                return;
+            }
+
+            Object.values(statusClasses).forEach((classes) => {
+                statusElement.classList.remove(...classes);
+            });
+
+            statusElement.classList.add(...statusClasses.base);
+
+            if (type === 'error') {
+                statusElement.classList.add(...statusClasses.error);
+            } else {
+                statusElement.classList.add(...statusClasses.success);
+            }
+
+            statusElement.textContent = message;
+            statusElement.classList.remove('hidden');
+        };
+
+        const disableForm = () => {
+            pollInputs.forEach((input) => {
+                input.disabled = true;
+            });
+
+            if (submitButton) {
+                submitButton.disabled = true;
+                submitButton.classList.add('opacity-60', 'cursor-not-allowed');
+            }
+        };
+
+        const enableForm = () => {
+            pollInputs.forEach((input) => {
+                input.disabled = false;
+            });
+
+            if (submitButton) {
+                submitButton.disabled = false;
+                submitButton.classList.remove('opacity-60', 'cursor-not-allowed');
+            }
+        };
+
+        const updatePollStats = (poll) => {
+            if (!poll) {
+                return;
+            }
+
+            if (countsBangla.yes) {
+                countsBangla.yes.textContent = poll.totals_bangla.yes;
+            }
+
+            if (countsBangla.no) {
+                countsBangla.no.textContent = poll.totals_bangla.no;
+            }
+
+            if (countsBangla.no_opinion) {
+                countsBangla.no_opinion.textContent = poll.totals_bangla.no_opinion;
+            }
+
+            if (percentagesBangla.yes) {
+                percentagesBangla.yes.textContent = `${poll.percentages_bangla.yes}%`;
+            }
+
+            if (percentagesBangla.no) {
+                percentagesBangla.no.textContent = `${poll.percentages_bangla.no}%`;
+            }
+
+            if (percentagesBangla.no_opinion) {
+                percentagesBangla.no_opinion.textContent = `${poll.percentages_bangla.no_opinion}%`;
+            }
+
+            if (percentages.yes) {
+                percentages.yes.textContent = `${poll.percentages.yes}%`;
+            }
+
+            if (percentages.no) {
+                percentages.no.textContent = `${poll.percentages.no}%`;
+            }
+
+            if (percentages.no_opinion) {
+                percentages.no_opinion.textContent = `${poll.percentages.no_opinion}%`;
+            }
+
+            if (progressBars.yes) {
+                progressBars.yes.style.width = `${poll.percentages.yes}%`;
+            }
+
+            if (progressBars.no) {
+                progressBars.no.style.width = `${poll.percentages.no}%`;
+            }
+
+            if (progressBars.no_opinion) {
+                progressBars.no_opinion.style.width = `${poll.percentages.no_opinion}%`;
+            }
+
+            if (totalBangla) {
+                totalBangla.textContent = poll.totals_bangla.total;
+            }
+        };
+
+        const markAsVoted = () => {
+            if (pollId) {
+                window.localStorage.setItem(`poll_voted_${pollId}`, '1');
+            }
+        };
+
+        const hasVoted = pollId && window.localStorage.getItem(`poll_voted_${pollId}`) === '1';
+
+        if (hasVoted) {
+            disableForm();
+
+            if (alreadyVotedMessage) {
+                showStatus(alreadyVotedMessage, 'success');
+            }
+        }
+
+        const handleSubmit = async (event) => {
+            event.preventDefault();
+
+            if (!submitButton) {
+                return;
+            }
+
+            const formData = new FormData(pollVoteForm);
+            const selectedOption = formData.get('option');
+
+            if (!selectedOption) {
+                return;
+            }
+
+            disableForm();
+
+            try {
+                const response = await fetch(pollVoteForm.action, {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'X-CSRF-TOKEN': csrfToken,
+                    },
+                    body: formData,
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => null);
+                    const message = errorData?.message || errorMessage;
+                    showStatus(message, 'error');
+                    enableForm();
+                    return;
+                }
+
+                const data = await response.json();
+                updatePollStats(data.poll);
+                markAsVoted();
+                showStatus(data.message || successMessage, 'success');
+            } catch (error) {
+                enableForm();
+                pollVoteForm.removeEventListener('submit', handleSubmit);
+                pollVoteForm.submit();
+            }
+        };
+
+        pollVoteForm.addEventListener('submit', handleSubmit);
+    }
 });
 
 // Livewire পেজের কোনো অংশ আপডেট করা শেষ করলে এই ইভেন্টটি কাজ করবে

--- a/resources/views/front/polls/index.blade.php
+++ b/resources/views/front/polls/index.blade.php
@@ -13,11 +13,14 @@
     </section>
 
     <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-10">
-        @if (session('status'))
-            <div class="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-                {{ session('status') }}
-            </div>
-        @endif
+        @php($statusMessage = session('status'))
+        <div id="pollStatusMessage"
+             class="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 {{ $statusMessage ? '' : 'hidden' }}"
+             role="status"
+             aria-live="polite"
+             data-poll-status>
+            {{ $statusMessage }}
+        </div>
 
         @php($latestPoll = $polls->first())
         @php($displayPoll = $activePoll ?? $latestPoll)
@@ -34,28 +37,43 @@
                     @endif
 
                     @if($activePoll && $displayPoll->id === $activePoll->id)
-                        <form action="{{ route('polls.vote', $activePoll) }}" method="POST" class="mt-6 space-y-3">
+                        <form
+                            id="pollVoteForm"
+                            action="{{ route('polls.vote', $activePoll) }}"
+                            method="POST"
+                            class="mt-6 space-y-3"
+                            data-poll-id="{{ $activePoll->id }}"
+                            data-success-message="আপনার ভোটের জন্য ধন্যবাদ!"
+                            data-error-message="দুঃখিত! ভোট সম্পন্ন করা যায়নি। অনুগ্রহ করে পুনরায় চেষ্টা করুন।"
+                            data-already-voted-message="আপনি ইতোমধ্যেই এই জরিপে ভোট দিয়েছেন।"
+                        >
                             @csrf
                             <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
                                 <div class="flex items-center gap-3">
                                     <input type="radio" name="option" value="yes" class="h-4 w-4 text-indigo-600" required>
-                                    <span class="font-medium text-slate-800">হ্যাঁ ({{ $activePoll->yes_vote_bangla }} ভোট)</span>
+                                    <span class="font-medium text-slate-800">
+                                        হ্যাঁ (<span data-poll-count-bangla="yes">{{ $activePoll->yes_vote_bangla }}</span> ভোট)
+                                    </span>
                                 </div>
-                                <span class="text-sm text-slate-500">{{ $activePoll->yes_vote_percent_bangla }}%</span>
+                                <span class="text-sm text-slate-500" data-poll-percent-bangla="yes">{{ $activePoll->yes_vote_percent_bangla }}%</span>
                             </label>
                             <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
                                 <div class="flex items-center gap-3">
                                     <input type="radio" name="option" value="no" class="h-4 w-4 text-indigo-600" required>
-                                    <span class="font-medium text-slate-800">না ({{ $activePoll->no_vote_bangla }} ভোট)</span>
+                                    <span class="font-medium text-slate-800">
+                                        না (<span data-poll-count-bangla="no">{{ $activePoll->no_vote_bangla }}</span> ভোট)
+                                    </span>
                                 </div>
-                                <span class="text-sm text-slate-500">{{ $activePoll->no_vote_percent_bangla }}%</span>
+                                <span class="text-sm text-slate-500" data-poll-percent-bangla="no">{{ $activePoll->no_vote_percent_bangla }}%</span>
                             </label>
                             <label class="flex items-center justify-between rounded-lg border border-slate-200 px-4 py-3 hover:border-indigo-500">
                                 <div class="flex items-center gap-3">
                                     <input type="radio" name="option" value="no_opinion" class="h-4 w-4 text-indigo-600" required>
-                                    <span class="font-medium text-slate-800">মতামত নেই ({{ $activePoll->no_opinion_bangla }} ভোট)</span>
+                                    <span class="font-medium text-slate-800">
+                                        মতামত নেই (<span data-poll-count-bangla="no_opinion">{{ $activePoll->no_opinion_bangla }}</span> ভোট)
+                                    </span>
                                 </div>
-                                <span class="text-sm text-slate-500">{{ $activePoll->no_opinion_vote_percent_bangla }}%</span>
+                                <span class="text-sm text-slate-500" data-poll-percent-bangla="no_opinion">{{ $activePoll->no_opinion_vote_percent_bangla }}%</span>
                             </label>
                             <button type="submit" class="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700">
                                 এখনই ভোট দিন
@@ -67,7 +85,9 @@
                         </div>
                     @endif
 
-                    <p class="mt-4 text-xs text-slate-500">মোট ভোট: {{ $displayPoll->total_vote_bangla }} | প্রকাশিত: {{ $displayPoll->poll_date_bangla }}</p>
+                    <p class="mt-4 text-xs text-slate-500">
+                        মোট ভোট: <span data-poll-total-bangla>{{ $displayPoll->total_vote_bangla }}</span> | প্রকাশিত: {{ $displayPoll->poll_date_bangla }}
+                    </p>
                 </div>
 
                 <div class="rounded-xl border border-slate-200 bg-white shadow-sm p-6">
@@ -76,28 +96,28 @@
                         <li>
                             <div class="flex items-center justify-between text-sm font-medium text-slate-700">
                                 <span>হ্যাঁ</span>
-                                <span>{{ $displayPoll->yes_vote_percent }}%</span>
+                                <span data-poll-percent="yes">{{ $displayPoll->yes_vote_percent }}%</span>
                             </div>
                             <div class="mt-2 h-2 w-full rounded-full bg-slate-200">
-                                <div class="h-full rounded-full bg-emerald-500" style="width: {{ $displayPoll->yes_vote_percent }}%"></div>
+                                <div class="h-full rounded-full bg-emerald-500" style="width: {{ $displayPoll->yes_vote_percent }}%" data-poll-progress="yes"></div>
                             </div>
                         </li>
                         <li>
                             <div class="flex items-center justify-between text-sm font-medium text-slate-700">
                                 <span>না</span>
-                                <span>{{ $displayPoll->no_vote_percent }}%</span>
+                                <span data-poll-percent="no">{{ $displayPoll->no_vote_percent }}%</span>
                             </div>
                             <div class="mt-2 h-2 w-full rounded-full bg-slate-200">
-                                <div class="h-full rounded-full bg-rose-500" style="width: {{ $displayPoll->no_vote_percent }}%"></div>
+                                <div class="h-full rounded-full bg-rose-500" style="width: {{ $displayPoll->no_vote_percent }}%" data-poll-progress="no"></div>
                             </div>
                         </li>
                         <li>
                             <div class="flex items-center justify-between text-sm font-medium text-slate-700">
                                 <span>মতামত নেই</span>
-                                <span>{{ $displayPoll->no_opinion_vote_percent }}%</span>
+                                <span data-poll-percent="no_opinion">{{ $displayPoll->no_opinion_vote_percent }}%</span>
                             </div>
                             <div class="mt-2 h-2 w-full rounded-full bg-slate-200">
-                                <div class="h-full rounded-full bg-amber-500" style="width: {{ $displayPoll->no_opinion_vote_percent }}%"></div>
+                                <div class="h-full rounded-full bg-amber-500" style="width: {{ $displayPoll->no_opinion_vote_percent }}%" data-poll-progress="no_opinion"></div>
                             </div>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- add JSON responses to the poll vote endpoint for AJAX requests
- enhance the public poll page with data attributes for dynamic updates and status messaging
- implement a front-end script that submits poll votes asynchronously, updates results, and persists a local voted state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e00c0b720c832e8bb31fb2cc38dc15