### PR TITLE
Fix poll vote response type

### DIFF
--- a/app/Http/Controllers/Frontend/PollController.php
+++ b/app/Http/Controllers/Frontend/PollController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Frontend;
 use App\Http\Controllers\Controller;
 use App\Models\GeneralSetting;
 use App\Models\Poll;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -43,7 +44,7 @@ class PollController extends Controller
     /**
      * Store the vote for the provided poll.
      */
-    public function vote(Request $request, Poll $poll): RedirectResponse
+    public function vote(Request $request, Poll $poll): RedirectResponse|JsonResponse
     {
         $validated = $request->validate([
             'option' => ['required', 'in:yes,no,no_opinion'],


### PR DESCRIPTION
## Summary
- allow the frontend poll vote action to return either redirect or JSON responses to match actual behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e01090c944832ea2a72aa16be37d3c