### PR TITLE
Add dashboard support for video posts

### DIFF
--- a/app/Http/Controllers/Frontend/PostController.php
+++ b/app/Http/Controllers/Frontend/PostController.php
@@ -29,6 +29,12 @@ class PostController extends Controller
             'author' => $post->author?->name,
         ];
 
+        if ($post->isVideo()) {
+            $seo['type'] = 'video.other';
+            $seo['video'] = $post->video_embed_url;
+            $seo['twitter_card'] = 'player';
+        }
+
         return view('front.post', compact('post', 'seo', 'settings'));
     }
 

--- a/app/Livewire/Admin/PostsTable.php
+++ b/app/Livewire/Admin/PostsTable.php
@@ -76,7 +76,7 @@ class PostsTable extends Component
         $currentUser = Auth::user();
 
         // পোস্টের জন্য মূল কোয়েরি শুরু করুন
-        $postsQuery = Post::with(['category', 'subCategory']);
+        $postsQuery = Post::with(['category', 'subCategory', 'author']);
 
         // ব্যবহারকারী যদি 'Admin' না হন, তাহলে শুধুমাত্র তার নিজের পোস্ট দেখান
         if (! $currentUser->hasRole('Admin')) {
@@ -92,6 +92,9 @@ class PostsTable extends Component
                     $nested->where('title', 'like', $searchTerm)
                         ->orWhere('slug', 'like', $searchTerm)
                         ->orWhere('meta_title', 'like', $searchTerm)
+                        ->orWhere('content_type', 'like', $searchTerm)
+                        ->orWhere('video_url', 'like', $searchTerm)
+                        ->orWhere('video_provider', 'like', $searchTerm)
                         ->orWhereHas('category', function ($categoryQuery) use ($searchTerm) {
                             $categoryQuery->where('name', 'like', $searchTerm);
                         })

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -7,11 +7,20 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 class Post extends Model
 {
     use HasFactory;
+
+    public const CONTENT_TYPE_ARTICLE = 'article';
+
+    public const CONTENT_TYPE_VIDEO = 'video';
+
+    public const VIDEO_PROVIDER_YOUTUBE = 'youtube';
+
+    public const VIDEO_PROVIDER_VIMEO = 'vimeo';
 
     protected $fillable = [
         'user_id',
@@ -19,7 +28,11 @@ class Post extends Model
         'sub_category_id',
         'title',
         'slug',
+        'content_type',
         'thumbnail_path',
+        'video_url',
+        'video_provider',
+        'video_id',
         'description',
         'is_featured',
         'allow_comments',
@@ -33,6 +46,10 @@ class Post extends Model
         'is_featured' => 'boolean',
         'allow_comments' => 'boolean',
         'is_indexable' => 'boolean',
+        'content_type' => 'string',
+        'video_url' => 'string',
+        'video_provider' => 'string',
+        'video_id' => 'string',
     ];
 
     public function getRouteKeyName(): string
@@ -62,10 +79,66 @@ class Post extends Model
         });
     }
 
+    protected function videoEmbedUrl(): Attribute
+    {
+        return Attribute::get(function () {
+            return static::videoEmbedUrlFor($this->video_provider, $this->video_id);
+        });
+    }
+
+    protected function videoEmbedHtml(): Attribute
+    {
+        return Attribute::get(function () {
+            return static::videoEmbedHtmlFor($this->video_provider, $this->video_id, $this->title);
+        });
+    }
+
     protected function excerpt(): Attribute
     {
         return Attribute::get(function () {
             return Str::limit(strip_tags((string) $this->description), 160);
         });
+    }
+
+    public function isVideo(): bool
+    {
+        return $this->content_type === self::CONTENT_TYPE_VIDEO;
+    }
+
+    public function isArticle(): bool
+    {
+        return $this->content_type === self::CONTENT_TYPE_ARTICLE;
+    }
+
+    public static function videoEmbedUrlFor(?string $provider, ?string $videoId): ?string
+    {
+        if (! $provider || ! $videoId) {
+            return null;
+        }
+
+        return match ($provider) {
+            self::VIDEO_PROVIDER_YOUTUBE => 'https://www.youtube.com/embed/'.$videoId,
+            self::VIDEO_PROVIDER_VIMEO => 'https://player.vimeo.com/video/'.$videoId,
+            default => null,
+        };
+    }
+
+    public static function videoEmbedHtmlFor(?string $provider, ?string $videoId, ?string $title = null): ?HtmlString
+    {
+        $embedUrl = static::videoEmbedUrlFor($provider, $videoId);
+
+        if (! $embedUrl) {
+            return null;
+        }
+
+        $videoTitle = $title ?: 'Embedded video';
+
+        $iframe = sprintf(
+            '<iframe src="%s" title="%s" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe>',
+            $embedUrl,
+            e($videoTitle)
+        );
+
+        return new HtmlString('<div class="video-embed">'.$iframe.'</div>');
     }
 }

--- a/database/migrations/2025_10_07_000002_add_video_fields_to_posts_table.php
+++ b/database/migrations/2025_10_07_000002_add_video_fields_to_posts_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            if (! Schema::hasColumn('posts', 'content_type')) {
+                $table->string('content_type')->default('article')->after('slug');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_url')) {
+                $table->string('video_url', 500)->nullable()->after('thumbnail_path');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_provider')) {
+                $table->string('video_provider', 50)->nullable()->after('video_url');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_id')) {
+                $table->string('video_id', 100)->nullable()->after('video_provider');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            if (Schema::hasColumn('posts', 'video_id')) {
+                $table->dropColumn('video_id');
+            }
+
+            if (Schema::hasColumn('posts', 'video_provider')) {
+                $table->dropColumn('video_provider');
+            }
+
+            if (Schema::hasColumn('posts', 'video_url')) {
+                $table->dropColumn('video_url');
+            }
+
+            if (Schema::hasColumn('posts', 'content_type')) {
+                $table->dropColumn('content_type');
+            }
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -11,3 +11,21 @@
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
 }
+
+.video-embed {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+    background-color: #000;
+    border-radius: 0.75rem;
+    overflow: hidden;
+}
+
+.video-embed iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}

--- a/resources/views/back/pages/posts/index.blade.php
+++ b/resources/views/back/pages/posts/index.blade.php
@@ -5,7 +5,7 @@
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
             <div>
                 <h1 class="page-title">Posts</h1>
-                <p class="text-muted">Manage blog posts, featured options, and metadata.</p>
+                <p class="text-muted">Manage articles, video posts, featured options, and metadata.</p>
             </div>
             <a href="{{ route('admin.posts.create') }}" class="btn btn-primary">Create New Post</a>
         </div>

--- a/resources/views/front/home.blade.php
+++ b/resources/views/front/home.blade.php
@@ -24,6 +24,12 @@
                 @if ($post->thumbnail_url)
                     <a href="{{ route('posts.show', $post) }}" class="relative block aspect-[16/9] overflow-hidden bg-slate-100">
                         <img src="{{ $post->thumbnail_url }}" alt="{{ $post->title }}" class="h-full w-full object-cover transition duration-500 group-hover:scale-105">
+                        @if($post->isVideo())
+                            <span class="absolute bottom-3 left-3 inline-flex items-center gap-1 rounded-full bg-black/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                                <i class="fas fa-play text-[10px]"></i>
+                                Video
+                            </span>
+                        @endif
                     </a>
                 @endif
                 <div class="flex flex-1 flex-col p-6">
@@ -33,13 +39,19 @@
                         @endif
                         <span class="text-slate-400">•</span>
                         <time datetime="{{ optional($post->created_at)->toDateString() }}" class="text-slate-500">{{ optional($post->created_at)->format('M d, Y') }}</time>
+                        @if($post->isVideo())
+                            <span class="text-slate-400">•</span>
+                            <span class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 font-semibold text-indigo-600">Video</span>
+                        @endif
                     </div>
                     <h2 class="mt-3 text-xl font-semibold text-slate-900 group-hover:text-indigo-600">
                         <a href="{{ route('posts.show', $post) }}">{{ $post->title }}</a>
                     </h2>
                     <p class="mt-3 text-sm text-slate-600 flex-1">{{ $post->excerpt }}</p>
                     <div class="mt-6 flex items-center justify-between text-sm text-indigo-600">
-                        <a href="{{ route('posts.show', $post) }}" class="font-semibold hover:text-indigo-700">Read full story</a>
+                        <a href="{{ route('posts.show', $post) }}" class="font-semibold hover:text-indigo-700">
+                            {{ $post->isVideo() ? 'Watch video' : 'Read full story' }}
+                        </a>
                         @if($post->author)
                             <span class="text-slate-500">By {{ $post->author->name }}</span>
                         @endif

--- a/resources/views/front/post.blade.php
+++ b/resources/views/front/post.blade.php
@@ -47,7 +47,11 @@
             </div>
         </header>
 
-        @if ($post->thumbnail_url)
+        @if ($post->isVideo() && $post->video_embed_html)
+            <div class="mt-8">
+                {!! $post->video_embed_html !!}
+            </div>
+        @elseif ($post->thumbnail_url)
             <figure class="mt-8">
                 <img src="{{ $post->thumbnail_url }}" alt="{{ $post->title }}" class="w-full rounded-xl object-cover shadow-lg">
             </figure>

--- a/resources/views/layouts/front.blade.php
+++ b/resources/views/layouts/front.blade.php
@@ -19,6 +19,10 @@
     @if(!empty($seo['image']))
         <meta property="og:image" content="{{ $seo['image'] }}">
     @endif
+    @if(!empty($seo['video']))
+        <meta property="og:video" content="{{ $seo['video'] }}">
+        <meta property="og:video:type" content="text/html">
+    @endif
     @if(!empty($seo['published_time']))
         <meta property="article:published_time" content="{{ $seo['published_time'] }}">
     @endif
@@ -26,11 +30,16 @@
         <meta property="article:modified_time" content="{{ $seo['modified_time'] }}">
     @endif
 
-    <meta name="twitter:card" content="{{ !empty($seo['image']) ? 'summary_large_image' : 'summary' }}">
+    <meta name="twitter:card" content="{{ $seo['twitter_card'] ?? (!empty($seo['image']) ? 'summary_large_image' : 'summary') }}">
     <meta name="twitter:title" content="{{ $seo['title'] ?? '' }}">
     <meta name="twitter:description" content="{{ $seo['description'] ?? '' }}">
     @if(!empty($seo['image']))
         <meta name="twitter:image" content="{{ $seo['image'] }}">
+    @endif
+    @if(!empty($seo['video']))
+        <meta name="twitter:player" content="{{ $seo['video'] }}">
+        <meta name="twitter:player:width" content="1280">
+        <meta name="twitter:player:height" content="720">
     @endif
 
     <link rel="alternate" type="application/rss+xml" title="{{ $settings->site_title ?? config('app.name') }} RSS Feed" href="{{ route('feed') }}">

--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -1,18 +1,29 @@
+@php use App\Models\Post; @endphp
 <div>
     <form wire:submit.prevent="save" class="card card-fluid">
         <div class="card-body">
             <div class="form-row">
-                <div class="form-group col-md-8">
+                <div class="form-group col-md-6">
                     <label for="postTitle">Post Title <span class="text-danger">*</span></label>
                     <input type="text" id="postTitle" class="form-control @error('title') is-invalid @enderror" wire:model.defer="title" placeholder="Enter post title">
                     @error('title')
                         <div class="invalid-feedback">{{ $message }}</div>
                     @enderror
                 </div>
-                <div class="form-group col-md-4">
+                <div class="form-group col-md-3">
                     <label for="postSlug">Slug</label>
                     <input type="text" id="postSlug" class="form-control @error('slug') is-invalid @enderror" wire:model.defer="slug" placeholder="Auto generated from title">
                     @error('slug')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="contentType">Post Type <span class="text-danger">*</span></label>
+                    <select id="contentType" class="form-control @error('content_type') is-invalid @enderror" wire:model.live="content_type">
+                        <option value="{{ Post::CONTENT_TYPE_ARTICLE }}">Article</option>
+                        <option value="{{ Post::CONTENT_TYPE_VIDEO }}">Video</option>
+                    </select>
+                    @error('content_type')
                         <div class="invalid-feedback">{{ $message }}</div>
                     @enderror
                 </div>
@@ -44,6 +55,29 @@
                     @enderror
                 </div>
             </div>
+
+            @if ($content_type === Post::CONTENT_TYPE_VIDEO)
+                <div class="card card-body border mb-4">
+                    <h5 class="card-title mb-3">Video Details</h5>
+                    <div class="form-group">
+                        <label for="videoUrl">Video URL <span class="text-danger">*</span></label>
+                        <input type="url" id="videoUrl" class="form-control @error('video_url') is-invalid @enderror" wire:model.live.debounce.500ms="video_url" placeholder="https://www.youtube.com/watch?v=...">
+                        @error('video_url')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                        @if ($video_provider)
+                            <p class="text-muted small mt-2 mb-0">Detected platform: {{ ucfirst($video_provider) }}</p>
+                        @endif
+                    </div>
+
+                    @if ($video_preview_html)
+                        <div class="mt-3">
+                            <p class="text-muted small mb-2">Preview</p>
+                            {!! $video_preview_html !!}
+                        </div>
+                    @endif
+                </div>
+            @endif
 
             <div class="form-group">
                 <label for="postDescription">Post Description <span class="text-danger">*</span></label>

--- a/resources/views/livewire/admin/posts-table.blade.php
+++ b/resources/views/livewire/admin/posts-table.blade.php
@@ -1,10 +1,13 @@
-@php use Illuminate\Support\Str; @endphp
+@php
+    use App\Models\Post;
+    use Illuminate\Support\Str;
+@endphp
 <div>
     <div class="card card-fluid">
         <div class="card-body">
             <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-3">
                 <div class="w-100 w-md-50">
-                    <input type="search" wire:model.live.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug, meta title, category or sub category">
+                    <input type="search" wire:model.live.debounce.500ms="search" class="form-control" placeholder="Search posts by title, slug, meta title, video URL, category or sub category">
                 </div>
                 <div class="text-muted small">
                     Showing {{ $posts->firstItem() ?? 0 }} - {{ $posts->lastItem() ?? 0 }} of {{ $posts->total() }} posts
@@ -17,6 +20,7 @@
                         <tr>
                             <th>#</th>
                             <th>Title</th>
+                            <th>Type</th>
                             <th>Author</th>
                             <th>Category</th>
                             <th>Featured</th>
@@ -36,6 +40,11 @@
                                     @if ($post->meta_title)
                                         <div class="text-muted small">Meta: {{ Str::limit($post->meta_title, 45) }}</div>
                                     @endif
+                                </td>
+                                <td>
+                                    <span class="badge {{ $post->isVideo() ? 'badge-info' : 'badge-secondary' }}">
+                                        {{ $post->isVideo() ? 'Video' : 'Article' }}
+                                    </span>
                                 </td>
                                 <td>
                                     <div>{{ $post->author?->name ?? 'Unknown' }}</div>
@@ -76,7 +85,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="9" class="text-center text-muted">No posts found.</td>
+                                <td colspan="10" class="text-center text-muted">No posts found.</td>
                             </tr>
                         @endforelse
                     </tbody>


### PR DESCRIPTION
## Summary
- add migration and model helpers to support video metadata on posts
- extend the admin post form and table to create, preview, and manage video posts
- enhance public post rendering and SEO with responsive video embeds and social metadata

## Testing
- php artisan test *(fails: vendor/autoload.php missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e016deffa0832e96def0775347ec80