### PR TITLE
Enhance video post management options

### DIFF
--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -15,7 +15,7 @@ class HomeController extends Controller
         $settings = $this->settings();
 
         $postsQuery = Post::query()
-            ->with(['category', 'author'])
+            ->with(['category', 'author', 'playlist'])
             ->where('is_indexable', true)
             ->latest('created_at');
 

--- a/app/Http/Controllers/Frontend/PostController.php
+++ b/app/Http/Controllers/Frontend/PostController.php
@@ -12,6 +12,8 @@ class PostController extends Controller
 {
     public function show(Post $post)
     {
+        $post->loadMissing(['category', 'author', 'playlist']);
+
         $settings = $this->settings();
 
         $image = $post->thumbnail_path ? Storage::url($post->thumbnail_path) : null;
@@ -33,6 +35,12 @@ class PostController extends Controller
             $seo['type'] = 'video.other';
             $seo['video'] = $post->video_embed_url;
             $seo['twitter_card'] = 'player';
+            if ($post->video_duration) {
+                $seo['video_duration'] = $post->video_duration;
+            }
+            if ($post->playlist) {
+                $seo['video_playlist'] = $post->playlist->name;
+            }
         }
 
         return view('front.post', compact('post', 'seo', 'settings'));

--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Admin;
 use App\Models\Category;
 use App\Models\Post;
 use App\Models\SubCategory;
+use App\Models\VideoPlaylist;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -28,6 +29,12 @@ class PostForm extends Component
     public ?string $video_url = null;
     public ?string $video_provider = null;
     public ?string $video_id = null;
+    public string $video_source = Post::VIDEO_SOURCE_EMBED;
+    public ?string $video_embed_code = null;
+    public $video_upload;
+    public ?string $existingVideoPath = null;
+    public ?string $video_duration = null;
+    public ?string $video_playlist_id = '';
     public ?string $video_preview_html = null;
     public bool $is_featured = false;
     public bool $allow_comments = true;
@@ -57,6 +64,11 @@ class PostForm extends Component
             $this->video_url = $post->video_url;
             $this->video_provider = $post->video_provider;
             $this->video_id = $post->video_id;
+            $this->video_source = $post->video_source ?: ($post->video_path ? Post::VIDEO_SOURCE_UPLOAD : Post::VIDEO_SOURCE_EMBED);
+            $this->video_embed_code = $post->video_embed_code;
+            $this->existingVideoPath = $post->video_path;
+            $this->video_duration = $post->video_duration;
+            $this->video_playlist_id = $post->video_playlist_id ? (string) $post->video_playlist_id : '';
             $this->video_preview_html = $post->video_embed_html?->toHtml();
             $this->is_featured = (bool) $post->is_featured;
             $this->allow_comments = (bool) $post->allow_comments;
@@ -77,8 +89,12 @@ class PostForm extends Component
             $this->slug = $this->generateUniqueSlug($value);
         }
 
-        if ($this->content_type === Post::CONTENT_TYPE_VIDEO && $this->video_provider && $this->video_id) {
-            $this->video_preview_html = Post::videoEmbedHtmlFor($this->video_provider, $this->video_id, $value)?->toHtml();
+        if ($this->content_type === Post::CONTENT_TYPE_VIDEO) {
+            if ($this->video_provider && $this->video_id && $this->video_source !== Post::VIDEO_SOURCE_UPLOAD && blank($this->video_embed_code)) {
+                $this->video_preview_html = Post::videoEmbedHtmlFor($this->video_provider, $this->video_id, $value)?->toHtml();
+            } else {
+                $this->updateVideoPreview();
+            }
         }
     }
 
@@ -92,7 +108,11 @@ class PostForm extends Component
     {
         if ($value === Post::CONTENT_TYPE_VIDEO) {
             $this->content_type = Post::CONTENT_TYPE_VIDEO;
-            $this->updateVideoPreviewFromUrl();
+            if (! in_array($this->video_source, [Post::VIDEO_SOURCE_EMBED, Post::VIDEO_SOURCE_UPLOAD], true)) {
+                $this->video_source = Post::VIDEO_SOURCE_EMBED;
+            }
+
+            $this->updateVideoPreview();
 
             return;
         }
@@ -101,14 +121,75 @@ class PostForm extends Component
         $this->video_url = null;
         $this->video_provider = null;
         $this->video_id = null;
+        $this->video_source = Post::VIDEO_SOURCE_EMBED;
+        $this->video_embed_code = null;
+        $this->video_upload = null;
+        $this->existingVideoPath = null;
+        $this->video_duration = null;
+        $this->video_playlist_id = '';
         $this->video_preview_html = null;
-        $this->resetErrorBag('video_url');
+        $this->resetErrorBag(['video_url', 'video_embed_code', 'video_upload']);
     }
 
     public function updatedVideoUrl($value): void
     {
         $this->video_url = $value;
-        $this->updateVideoPreviewFromUrl();
+        $this->updateVideoPreview();
+    }
+
+    public function updatedVideoSource($value): void
+    {
+        if (! in_array($value, [Post::VIDEO_SOURCE_EMBED, Post::VIDEO_SOURCE_UPLOAD], true)) {
+            $this->video_source = Post::VIDEO_SOURCE_EMBED;
+        } else {
+            $this->video_source = $value;
+        }
+
+        if ($this->video_source === Post::VIDEO_SOURCE_UPLOAD) {
+            $this->video_provider = null;
+            $this->video_id = null;
+        }
+
+        $this->updateVideoPreview();
+    }
+
+    public function updatedVideoEmbedCode($value): void
+    {
+        $this->video_embed_code = $value;
+        $this->updateVideoPreview();
+    }
+
+    public function updatedVideoUpload($value): void
+    {
+        $this->video_upload = $value;
+        $this->updateVideoPreview();
+    }
+
+    public function updatedThumbnail($value): void
+    {
+        $this->thumbnail = $value;
+
+        if ($this->content_type === Post::CONTENT_TYPE_VIDEO) {
+            $this->updateVideoPreview();
+        }
+    }
+
+    public function removeExistingVideo(): void
+    {
+        if (! $this->existingVideoPath) {
+            return;
+        }
+
+        Storage::disk('public')->delete($this->existingVideoPath);
+        $this->existingVideoPath = null;
+
+        if ($this->post) {
+            $this->post->update(['video_path' => null]);
+        }
+
+        $this->dispatch('showToastr', type: 'success', message: 'Video file removed successfully.');
+
+        $this->updateVideoPreview();
     }
 
     public function updatedCategoryId($value): void
@@ -154,6 +235,10 @@ class PostForm extends Component
             $data['slug'] = $this->generateUniqueSlug($this->title);
         }
 
+        if ($this->content_type === Post::CONTENT_TYPE_VIDEO && ! in_array($this->video_source, [Post::VIDEO_SOURCE_EMBED, Post::VIDEO_SOURCE_UPLOAD], true)) {
+            $this->video_source = Post::VIDEO_SOURCE_EMBED;
+        }
+
         if (! $this->category_id) {
             $this->addError('category_id', 'Please select a category.');
             return null;
@@ -183,24 +268,88 @@ class PostForm extends Component
         $data['meta_keywords'] = $this->meta_keywords;
 
         if ($this->content_type === Post::CONTENT_TYPE_VIDEO) {
-            $videoData = $this->resolveVideoData($this->video_url);
+            $data['video_source'] = $this->video_source;
+            $duration = trim((string) $this->video_duration);
+            $data['video_duration'] = $duration !== '' ? $duration : null;
+            $data['video_playlist_id'] = $this->video_playlist_id ? (int) $this->video_playlist_id : null;
 
-            if (! $videoData) {
-                $this->addError('video_url', 'The video URL must be a valid YouTube or Vimeo link.');
+            if ($this->video_source === Post::VIDEO_SOURCE_UPLOAD) {
+                $storedPath = $this->existingVideoPath;
 
-                return null;
+                if ($this->video_upload) {
+                    if ($storedPath) {
+                        Storage::disk('public')->delete($storedPath);
+                    }
+
+                    $storedPath = $this->video_upload->store('videos', 'public');
+                    $this->video_upload = null;
+                }
+
+                if (! $storedPath) {
+                    $this->addError('video_upload', 'Please upload a video file.');
+
+                    return null;
+                }
+
+                $data['video_path'] = $storedPath;
+                $data['video_embed_code'] = null;
+                $data['video_url'] = null;
+                $data['video_provider'] = null;
+                $data['video_id'] = null;
+
+                $this->existingVideoPath = $storedPath;
+            } else {
+                $embedCode = $this->sanitizeEmbedCode($this->video_embed_code);
+                $videoUrl = trim((string) $this->video_url);
+                $embedUrl = $embedCode ? $this->extractVideoUrlFromEmbedCode($embedCode) : null;
+
+                $videoData = null;
+
+                if ($videoUrl !== '') {
+                    $videoData = $this->resolveVideoData($videoUrl);
+                }
+
+                if (! $videoData && $embedUrl) {
+                    $videoData = $this->resolveVideoData($embedUrl);
+                }
+
+                if (! $embedCode && ! $videoData) {
+                    $this->addError('video_embed_code', 'Please provide a valid embed code or video URL.');
+
+                    return null;
+                }
+
+                $data['video_embed_code'] = $embedCode;
+                $data['video_url'] = $videoUrl !== '' ? $videoUrl : null;
+
+                if ($videoData) {
+                    [$provider, $videoId] = $videoData;
+                    $data['video_provider'] = $provider;
+                    $data['video_id'] = $videoId;
+                } else {
+                    $data['video_provider'] = null;
+                    $data['video_id'] = null;
+                }
+
+                $data['video_path'] = null;
+
+                if ($this->existingVideoPath) {
+                    Storage::disk('public')->delete($this->existingVideoPath);
+                    $this->existingVideoPath = null;
+                }
             }
-
-            [$provider, $videoId] = $videoData;
-
-            $data['video_url'] = trim((string) $this->video_url);
-            $data['video_provider'] = $provider;
-            $data['video_id'] = $videoId;
         } else {
             $data['video_url'] = null;
             $data['video_provider'] = null;
             $data['video_id'] = null;
+            $data['video_source'] = null;
+            $data['video_embed_code'] = null;
+            $data['video_path'] = null;
+            $data['video_duration'] = null;
+            $data['video_playlist_id'] = null;
         }
+
+        unset($data['video_upload']);
 
         if ($this->thumbnail) {
             if ($this->existingThumbnail) {
@@ -237,6 +386,17 @@ class PostForm extends Component
     {
         $postId = $this->post?->id;
 
+        $videoUploadRules = ['nullable'];
+
+        if ($this->content_type === Post::CONTENT_TYPE_VIDEO && $this->video_source === Post::VIDEO_SOURCE_UPLOAD) {
+            $videoUploadRules = [
+                $this->existingVideoPath ? 'nullable' : 'required',
+                'file',
+                'mimetypes:video/mp4,video/quicktime,video/webm',
+                'max:204800',
+            ];
+        }
+
         return [
             'title' => ['required', 'string', 'max:255'],
             'slug' => [
@@ -249,21 +409,55 @@ class PostForm extends Component
             'description' => ['required', 'string'],
             'category_id' => ['nullable', 'integer', Rule::exists('categories', 'id')],
             'sub_category_id' => ['nullable', 'integer', Rule::exists('sub_categories', 'id')],
-            'video_url' => array_filter([
+            'video_source' => array_filter([
                 $this->content_type === Post::CONTENT_TYPE_VIDEO ? 'required' : 'nullable',
+                Rule::in([Post::VIDEO_SOURCE_EMBED, Post::VIDEO_SOURCE_UPLOAD]),
+            ]),
+            'video_embed_code' => [
+                'nullable',
                 'string',
-                'max:500',
-                $this->content_type === Post::CONTENT_TYPE_VIDEO ? 'url' : null,
                 function ($attribute, $value, $fail) {
-                    if ($this->content_type !== Post::CONTENT_TYPE_VIDEO) {
+                    if ($this->content_type !== Post::CONTENT_TYPE_VIDEO || $this->video_source !== Post::VIDEO_SOURCE_EMBED) {
                         return;
                     }
 
-                    if (! $this->resolveVideoData($value)) {
+                    $hasEmbed = trim((string) $value) !== '';
+                    $hasUrl = trim((string) $this->video_url) !== '';
+
+                    if (! $hasEmbed && ! $hasUrl) {
+                        $fail('Please provide an embed code or video URL.');
+                    }
+                },
+            ],
+            'video_url' => array_filter([
+                'nullable',
+                'string',
+                'max:500',
+                function ($attribute, $value, $fail) {
+                    if ($this->content_type !== Post::CONTENT_TYPE_VIDEO || $this->video_source !== Post::VIDEO_SOURCE_EMBED) {
+                        return;
+                    }
+
+                    $normalized = trim((string) $value);
+
+                    if ($normalized === '') {
+                        return;
+                    }
+
+                    if (! filter_var($normalized, FILTER_VALIDATE_URL)) {
+                        $fail('The video URL must be a valid URL.');
+
+                        return;
+                    }
+
+                    if (! $this->resolveVideoData($normalized)) {
                         $fail('The video URL must be a valid YouTube or Vimeo link.');
                     }
                 },
             ]),
+            'video_upload' => $videoUploadRules,
+            'video_duration' => ['nullable', 'string', 'max:50'],
+            'video_playlist_id' => ['nullable', 'integer', Rule::exists('video_playlists', 'id')],
             'meta_title' => ['nullable', 'string', 'max:255'],
             'meta_description' => ['nullable', 'string'],
             'meta_keywords' => ['nullable', 'string'],
@@ -340,6 +534,25 @@ class PostForm extends Component
         return $subCategories;
     }
 
+    #[Computed]
+    public function videoPlaylists()
+    {
+        $playlists = VideoPlaylist::query()
+            ->orderBy('name')
+            ->get();
+
+        if ($this->video_playlist_id && ! $playlists->contains('id', (int) $this->video_playlist_id)) {
+            $selectedPlaylist = VideoPlaylist::find($this->video_playlist_id);
+
+            if ($selectedPlaylist) {
+                $playlists->push($selectedPlaylist);
+                $playlists = $playlists->sortBy('name')->values();
+            }
+        }
+
+        return $playlists;
+    }
+
     public function render()
     {
         if ($this->lastSyncedDescription !== $this->description) {
@@ -350,39 +563,147 @@ class PostForm extends Component
         return view('livewire.admin.post-form');
     }
 
-    protected function updateVideoPreviewFromUrl(): void
+    protected function updateVideoPreview(): void
     {
-        $url = trim((string) $this->video_url);
+        $this->resetErrorBag(['video_url', 'video_embed_code', 'video_upload']);
 
-        if ($url === '') {
+        if ($this->content_type !== Post::CONTENT_TYPE_VIDEO) {
+            $this->video_preview_html = null;
+
+            return;
+        }
+
+        if ($this->video_source === Post::VIDEO_SOURCE_UPLOAD) {
+            $sourceUrl = null;
+
+            if ($this->video_upload) {
+                try {
+                    $sourceUrl = $this->video_upload->temporaryUrl();
+                } catch (\Throwable) {
+                    $sourceUrl = null;
+                }
+            } elseif ($this->existingVideoPath) {
+                $sourceUrl = Storage::url($this->existingVideoPath);
+            }
+
+            if ($sourceUrl) {
+                $poster = null;
+
+                if ($this->thumbnail) {
+                    try {
+                        $poster = $this->thumbnail->temporaryUrl();
+                    } catch (\Throwable) {
+                        $poster = null;
+                    }
+                } elseif ($this->existingThumbnail) {
+                    $poster = Storage::url($this->existingThumbnail);
+                }
+
+                $this->video_preview_html = $this->buildVideoTag($sourceUrl, $poster);
+            } else {
+                $this->video_preview_html = null;
+            }
+
+            $this->video_provider = null;
+            $this->video_id = null;
+
+            return;
+        }
+
+        $normalizedUrl = trim((string) $this->video_url);
+
+        if ($normalizedUrl === '') {
             $this->video_url = null;
         }
 
-        $this->resetErrorBag('video_url');
+        $embedCode = $this->sanitizeEmbedCode($this->video_embed_code);
+        $videoData = null;
 
-        if ($this->content_type !== Post::CONTENT_TYPE_VIDEO || blank($this->video_url)) {
-            $this->video_provider = null;
-            $this->video_id = null;
+        if ($embedCode) {
+            $this->video_preview_html = '<div class="video-embed">'.$embedCode.'</div>';
+            $embedUrl = $this->extractVideoUrlFromEmbedCode($embedCode);
+
+            if ($embedUrl) {
+                $videoData = $this->resolveVideoData($embedUrl);
+            }
+        } else {
             $this->video_preview_html = null;
 
-            return;
+            if ($this->video_url) {
+                $videoData = $this->resolveVideoData($this->video_url);
+
+                if ($videoData) {
+                    [$provider, $videoId] = $videoData;
+                    $this->video_preview_html = Post::videoEmbedHtmlFor($provider, $videoId, $this->title)?->toHtml();
+                }
+            }
         }
 
-        $videoData = $this->resolveVideoData($this->video_url);
-
-        if (! $videoData) {
+        if ($videoData) {
+            [$provider, $videoId] = $videoData;
+            $this->video_provider = $provider;
+            $this->video_id = $videoId;
+        } else {
             $this->video_provider = null;
             $this->video_id = null;
-            $this->video_preview_html = null;
+        }
+    }
 
-            return;
+    protected function sanitizeEmbedCode(?string $code): ?string
+    {
+        $normalized = trim((string) $code);
+
+        if ($normalized === '') {
+            return null;
         }
 
-        [$provider, $videoId] = $videoData;
+        $normalized = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $normalized) ?? '';
+        $normalized = preg_replace('/on[a-z]+\s*=\s*"[^"]*"/i', '', $normalized) ?? $normalized;
+        $normalized = preg_replace("/on[a-z]+\s*=\s*'[^']*'/i", '', $normalized) ?? $normalized;
 
-        $this->video_provider = $provider;
-        $this->video_id = $videoId;
-        $this->video_preview_html = Post::videoEmbedHtmlFor($provider, $videoId, $this->title)?->toHtml();
+        if (! Str::contains(Str::lower($normalized), '<iframe')) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    protected function extractVideoUrlFromEmbedCode(?string $code): ?string
+    {
+        if (! $code) {
+            return null;
+        }
+
+        if (preg_match('/<iframe[^>]*src\s*=\s*["\']([^"\']+)["\']/i', $code, $matches)) {
+            $url = trim((string) ($matches[1] ?? ''));
+
+            if ($url !== '' && filter_var($url, FILTER_VALIDATE_URL)) {
+                return $url;
+            }
+        }
+
+        return null;
+    }
+
+    protected function buildVideoTag(string $sourceUrl, ?string $poster = null): string
+    {
+        $attributes = collect([
+            'src' => $sourceUrl,
+            'controls' => true,
+            'preload' => 'metadata',
+            'poster' => $poster,
+            'title' => $this->title ?: 'Uploaded video',
+        ])->filter();
+
+        $attributeString = $attributes->map(function ($value, $key) {
+            if (is_bool($value)) {
+                return $value ? $key : null;
+            }
+
+            return sprintf('%s="%s"', $key, e($value));
+        })->filter()->implode(' ');
+
+        return '<div class="video-embed"><video '.$attributeString.'></video></div>';
     }
 
     protected function resolveVideoData(?string $url): ?array

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -22,6 +22,10 @@ class Post extends Model
 
     public const VIDEO_PROVIDER_VIMEO = 'vimeo';
 
+    public const VIDEO_SOURCE_EMBED = 'embed';
+
+    public const VIDEO_SOURCE_UPLOAD = 'upload';
+
     protected $fillable = [
         'user_id',
         'category_id',
@@ -33,6 +37,11 @@ class Post extends Model
         'video_url',
         'video_provider',
         'video_id',
+        'video_source',
+        'video_embed_code',
+        'video_path',
+        'video_duration',
+        'video_playlist_id',
         'description',
         'is_featured',
         'allow_comments',
@@ -50,6 +59,11 @@ class Post extends Model
         'video_url' => 'string',
         'video_provider' => 'string',
         'video_id' => 'string',
+        'video_source' => 'string',
+        'video_embed_code' => 'string',
+        'video_path' => 'string',
+        'video_duration' => 'string',
+        'video_playlist_id' => 'integer',
     ];
 
     public function getRouteKeyName(): string
@@ -72,6 +86,11 @@ class Post extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    public function playlist(): BelongsTo
+    {
+        return $this->belongsTo(VideoPlaylist::class, 'video_playlist_id');
+    }
+
     protected function thumbnailUrl(): Attribute
     {
         return Attribute::get(function () {
@@ -82,6 +101,18 @@ class Post extends Model
     protected function videoEmbedUrl(): Attribute
     {
         return Attribute::get(function () {
+            if ($this->video_source === self::VIDEO_SOURCE_UPLOAD && $this->video_path) {
+                return Storage::url($this->video_path);
+            }
+
+            if ($this->video_source === self::VIDEO_SOURCE_EMBED || (! $this->video_source && $this->video_embed_code)) {
+                $embedUrl = $this->extractUrlFromEmbedCode();
+
+                if ($embedUrl) {
+                    return $embedUrl;
+                }
+            }
+
             return static::videoEmbedUrlFor($this->video_provider, $this->video_id);
         });
     }
@@ -89,6 +120,48 @@ class Post extends Model
     protected function videoEmbedHtml(): Attribute
     {
         return Attribute::get(function () {
+            if ($this->content_type !== self::CONTENT_TYPE_VIDEO) {
+                return null;
+            }
+
+            if ($this->video_source === self::VIDEO_SOURCE_UPLOAD && $this->video_path) {
+                $poster = $this->thumbnail_path ? Storage::url($this->thumbnail_path) : null;
+                $videoUrl = Storage::url($this->video_path);
+
+                $attributes = [
+                    'src' => $videoUrl,
+                    'controls' => true,
+                    'preload' => 'metadata',
+                ];
+
+                if ($poster) {
+                    $attributes['poster'] = $poster;
+                }
+
+                $attributeString = collect($attributes)
+                    ->map(function ($value, $key) {
+                        if (is_bool($value)) {
+                            return $value ? $key : null;
+                        }
+
+                        return sprintf('%s="%s"', $key, e($value));
+                    })
+                    ->filter()
+                    ->implode(' ');
+
+                $title = e($this->title ?? 'Embedded video');
+
+                return new HtmlString('<div class="video-embed"><video '.$attributeString.' title="'.$title.'"></video></div>');
+            }
+
+            if ($this->video_source === self::VIDEO_SOURCE_EMBED || (! $this->video_source && $this->video_embed_code)) {
+                $code = $this->sanitizedEmbedCode();
+
+                if ($code) {
+                    return new HtmlString('<div class="video-embed">'.$code.'</div>');
+                }
+            }
+
             return static::videoEmbedHtmlFor($this->video_provider, $this->video_id, $this->title);
         });
     }
@@ -140,5 +213,43 @@ class Post extends Model
         );
 
         return new HtmlString('<div class="video-embed">'.$iframe.'</div>');
+    }
+
+    protected function sanitizedEmbedCode(): ?string
+    {
+        if (! $this->video_embed_code) {
+            return null;
+        }
+
+        $code = trim((string) $this->video_embed_code);
+
+        if ($code === '') {
+            return null;
+        }
+
+        $code = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $code) ?? '';
+        $code = preg_replace('/on[a-z]+\s*=\s*"[^"]*"/i', '', $code) ?? $code;
+        $code = preg_replace("/on[a-z]+\s*=\s*'[^']*'/i", '', $code) ?? $code;
+
+        $trimmed = trim($code);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+
+    protected function extractUrlFromEmbedCode(): ?string
+    {
+        $code = $this->sanitizedEmbedCode();
+
+        if (! $code) {
+            return null;
+        }
+
+        if (preg_match('/<iframe[^>]*src\s*=\s*["\']([^"\']+)["\']/i', $code, $matches)) {
+            $url = trim((string) ($matches[1] ?? ''));
+
+            return $url !== '' ? $url : null;
+        }
+
+        return null;
     }
 }

--- a/app/Models/VideoPlaylist.php
+++ b/app/Models/VideoPlaylist.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+class VideoPlaylist extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $playlist) {
+            if (blank($playlist->slug)) {
+                $playlist->slug = static::generateUniqueSlug($playlist->name ?? '');
+            }
+        });
+    }
+
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class, 'video_playlist_id');
+    }
+
+    protected static function generateUniqueSlug(?string $value): string
+    {
+        $base = Str::slug($value ?? '');
+
+        if ($base === '') {
+            return (string) Str::uuid();
+        }
+
+        $slug = $base;
+        $counter = 2;
+
+        while (static::where('slug', $slug)->exists()) {
+            $slug = $base.'-'.$counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/database/migrations/2025_10_07_000003_create_video_playlists_table.php
+++ b/database/migrations/2025_10_07_000003_create_video_playlists_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('video_playlists')) {
+            Schema::create('video_playlists', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->string('slug')->unique();
+                $table->text('description')->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('video_playlists');
+    }
+};

--- a/database/migrations/2025_10_07_000004_add_extended_video_fields_to_posts_table.php
+++ b/database/migrations/2025_10_07_000004_add_extended_video_fields_to_posts_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            if (! Schema::hasColumn('posts', 'video_source')) {
+                $table->string('video_source', 20)->nullable()->after('video_id');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_embed_code')) {
+                $table->text('video_embed_code')->nullable()->after('video_source');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_path')) {
+                $table->string('video_path', 500)->nullable()->after('video_embed_code');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_duration')) {
+                $table->string('video_duration', 50)->nullable()->after('video_path');
+            }
+
+            if (! Schema::hasColumn('posts', 'video_playlist_id')) {
+                $table->foreignId('video_playlist_id')
+                    ->nullable()
+                    ->after('video_duration')
+                    ->constrained('video_playlists')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            if (Schema::hasColumn('posts', 'video_playlist_id')) {
+                $table->dropConstrainedForeignId('video_playlist_id');
+            }
+
+            if (Schema::hasColumn('posts', 'video_duration')) {
+                $table->dropColumn('video_duration');
+            }
+
+            if (Schema::hasColumn('posts', 'video_path')) {
+                $table->dropColumn('video_path');
+            }
+
+            if (Schema::hasColumn('posts', 'video_embed_code')) {
+                $table->dropColumn('video_embed_code');
+            }
+
+            if (Schema::hasColumn('posts', 'video_source')) {
+                $table->dropColumn('video_source');
+            }
+        });
+    }
+};

--- a/resources/views/front/home.blade.php
+++ b/resources/views/front/home.blade.php
@@ -28,6 +28,9 @@
                             <span class="absolute bottom-3 left-3 inline-flex items-center gap-1 rounded-full bg-black/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
                                 <i class="fas fa-play text-[10px]"></i>
                                 Video
+                                @if($post->video_duration)
+                                    <span class="ml-2 text-[10px] font-medium normal-case tracking-normal">{{ $post->video_duration }}</span>
+                                @endif
                             </span>
                         @endif
                     </a>
@@ -42,6 +45,14 @@
                         @if($post->isVideo())
                             <span class="text-slate-400">•</span>
                             <span class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 font-semibold text-indigo-600">Video</span>
+                            @if($post->video_duration)
+                                <span class="text-slate-400">•</span>
+                                <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600">{{ $post->video_duration }}</span>
+                            @endif
+                            @if($post->playlist)
+                                <span class="text-slate-400">•</span>
+                                <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-medium text-slate-600">{{ $post->playlist->name }}</span>
+                            @endif
                         @endif
                     </div>
                     <h2 class="mt-3 text-xl font-semibold text-slate-900 group-hover:text-indigo-600">

--- a/resources/views/front/post.blade.php
+++ b/resources/views/front/post.blade.php
@@ -44,6 +44,16 @@
                     <span aria-hidden="true">•</span>
                     <time datetime="{{ optional($post->updated_at)->toDateString() }}">Updated {{ optional($post->updated_at)->format('F d, Y') }}</time>
                 @endif
+                @if($post->isVideo())
+                    @if($post->video_duration)
+                        <span aria-hidden="true">•</span>
+                        <span>{{ $post->video_duration }}</span>
+                    @endif
+                    @if($post->playlist)
+                        <span aria-hidden="true">•</span>
+                        <span>Part of the <span class="font-medium text-slate-700">{{ $post->playlist->name }}</span> series</span>
+                    @endif
+                @endif
             </div>
         </header>
 

--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -59,16 +59,77 @@
             @if ($content_type === Post::CONTENT_TYPE_VIDEO)
                 <div class="card card-body border mb-4">
                     <h5 class="card-title mb-3">Video Details</h5>
-                    <div class="form-group">
-                        <label for="videoUrl">Video URL <span class="text-danger">*</span></label>
-                        <input type="url" id="videoUrl" class="form-control @error('video_url') is-invalid @enderror" wire:model.live.debounce.500ms="video_url" placeholder="https://www.youtube.com/watch?v=...">
-                        @error('video_url')
-                            <div class="invalid-feedback">{{ $message }}</div>
-                        @enderror
-                        @if ($video_provider)
-                            <p class="text-muted small mt-2 mb-0">Detected platform: {{ ucfirst($video_provider) }}</p>
-                        @endif
+                    <div class="form-row">
+                        <div class="form-group col-md-4">
+                            <label for="videoSource">Video Source <span class="text-danger">*</span></label>
+                            <select id="videoSource" class="form-control @error('video_source') is-invalid @enderror" wire:model.live="video_source">
+                                <option value="{{ Post::VIDEO_SOURCE_EMBED }}">Embed Code</option>
+                                <option value="{{ Post::VIDEO_SOURCE_UPLOAD }}">Direct Upload</option>
+                            </select>
+                            @error('video_source')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="videoDuration">Duration</label>
+                            <input type="text" id="videoDuration" class="form-control @error('video_duration') is-invalid @enderror" wire:model.defer="video_duration" placeholder="e.g. 12:45 or 8 min">
+                            <small class="form-text text-muted">Optional – helps viewers understand the runtime.</small>
+                            @error('video_duration')
+                                <div class="invalid-feedback d-block">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="form-group col-md-4">
+                            <label for="videoPlaylist">Playlist / Series</label>
+                            <select id="videoPlaylist" class="form-control @error('video_playlist_id') is-invalid @enderror" wire:model="video_playlist_id">
+                                <option value="">None</option>
+                                @foreach ($this->videoPlaylists as $playlist)
+                                    <option value="{{ $playlist->id }}">{{ $playlist->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('video_playlist_id')
+                                <div class="invalid-feedback d-block">{{ $message }}</div>
+                            @enderror
+                        </div>
                     </div>
+
+                    @if ($video_source === Post::VIDEO_SOURCE_EMBED)
+                        <div class="form-group">
+                            <label for="videoEmbedCode">Embed Code</label>
+                            <textarea id="videoEmbedCode" rows="4" class="form-control @error('video_embed_code') is-invalid @enderror" wire:model.live.debounce.500ms="video_embed_code" placeholder="Paste the iframe embed code from YouTube, Vimeo, etc."></textarea>
+                            <small class="form-text text-muted">Embedding keeps your server fast and avoids heavy bandwidth usage.</small>
+                            @error('video_embed_code')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="form-group">
+                            <label for="videoUrl">Video URL</label>
+                            <input type="url" id="videoUrl" class="form-control @error('video_url') is-invalid @enderror" wire:model.live.debounce.500ms="video_url" placeholder="https://www.youtube.com/watch?v=...">
+                            <small class="form-text text-muted">Optional fallback – we’ll detect the platform automatically.</small>
+                            @error('video_url')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                            @if ($video_provider)
+                                <p class="text-muted small mt-2 mb-0">Detected platform: {{ ucfirst($video_provider) }}</p>
+                            @endif
+                        </div>
+                    @else
+                        <div class="form-group">
+                            <label for="videoUpload">Video File @if (! $existingVideoPath)<span class="text-danger">*</span>@endif</label>
+                            <input type="file" id="videoUpload" class="form-control-file @error('video_upload') is-invalid @enderror" wire:model="video_upload" accept="video/mp4,video/quicktime,video/webm">
+                            <small class="form-text text-muted">Upload MP4, MOV or WEBM files (max 200MB). Direct uploads use more storage and bandwidth.</small>
+                            @error('video_upload')
+                                <div class="invalid-feedback d-block">{{ $message }}</div>
+                            @enderror
+                            <div class="mt-3">
+                                @if ($existingVideoPath && ! $video_upload)
+                                    <div class="d-flex flex-column flex-md-row align-items-md-center gap-2">
+                                        <span class="text-muted small">Current file: <code>{{ $existingVideoPath }}</code></span>
+                                        <button type="button" class="btn btn-sm btn-outline-danger" wire:click="removeExistingVideo">Remove current video</button>
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+                    @endif
 
                     @if ($video_preview_html)
                         <div class="mt-3">


### PR DESCRIPTION
## Summary
- add video playlists and extend the posts table with source, embed, upload, and duration metadata for richer video posts
- upgrade the admin post form to handle embed codes or direct uploads with previews, duration tracking, and playlist selection
- surface video duration and playlist details on the public listing and post pages while keeping SEO data in sync

## Testing
- php -l app/Livewire/Admin/PostForm.php
- php -l app/Models/Post.php
- php -l app/Http/Controllers/Frontend/PostController.php
- php -l database/migrations/2025_10_07_000003_create_video_playlists_table.php
- php -l database/migrations/2025_10_07_000004_add_extended_video_fields_to_posts_table.php


------
https://chatgpt.com/codex/tasks/task_b_68e01e643e74832ebc50063f3b787c2b