### PR TITLE
Hide article-only fields when creating video posts

### DIFF
--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -406,7 +406,10 @@ class PostForm extends Component
                 Rule::unique('posts', 'slug')->ignore($postId),
             ],
             'content_type' => ['required', Rule::in([Post::CONTENT_TYPE_ARTICLE, Post::CONTENT_TYPE_VIDEO])],
-            'description' => ['required', 'string'],
+            'description' => array_filter([
+                $this->content_type === Post::CONTENT_TYPE_ARTICLE ? 'required' : 'nullable',
+                'string',
+            ]),
             'category_id' => ['nullable', 'integer', Rule::exists('categories', 'id')],
             'sub_category_id' => ['nullable', 'integer', Rule::exists('sub_categories', 'id')],
             'video_source' => array_filter([

--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -140,38 +140,42 @@
                 </div>
             @endif
 
-            <div class="form-group">
-                <label for="postDescription">Post Description <span class="text-danger">*</span></label>
-                <div wire:ignore data-post-description-editor>
-                    <textarea id="postDescription" class="form-control">{!! $description !!}</textarea>
-                </div>
-                <input type="hidden" id="postDescriptionData" wire:model="description">
-                @error('description')
-                    <div class="invalid-feedback d-block">{{ $message }}</div>
-                @enderror
-            </div>
-
-            <div class="form-row">
-                <div class="form-group col-md-6">
-                    <label for="thumbnail">Post Thumbnail</label>
-                    <input type="file" id="thumbnail" class="form-control-file @error('thumbnail') is-invalid @enderror" wire:model="thumbnail" accept="image/*">
-                    @error('thumbnail')
+            @if ($content_type === Post::CONTENT_TYPE_ARTICLE)
+                <div class="form-group">
+                    <label for="postDescription">Post Description <span class="text-danger">*</span></label>
+                    <div wire:ignore data-post-description-editor>
+                        <textarea id="postDescription" class="form-control">{!! $description !!}</textarea>
+                    </div>
+                    <input type="hidden" id="postDescriptionData" wire:model="description">
+                    @error('description')
                         <div class="invalid-feedback d-block">{{ $message }}</div>
                     @enderror
-                    <div class="mt-3">
-                        @if ($thumbnail)
-                            <p class="text-muted small mb-2">Preview:</p>
-                            <img src="{{ $thumbnail->temporaryUrl() }}" alt="Thumbnail preview" class="img-thumbnail" style="max-height: 180px;">
-                        @elseif ($existingThumbnail)
-                            <p class="text-muted small mb-2">Current thumbnail:</p>
-                            <div class="d-flex align-items-center gap-3">
-                                <img src="{{ asset('storage/' . $existingThumbnail) }}" alt="Current thumbnail" class="img-thumbnail" style="max-height: 180px;">
-                                <button type="button" class="btn btn-sm btn-outline-danger" wire:click="removeExistingThumbnail">Remove</button>
-                            </div>
-                        @endif
-                    </div>
                 </div>
-                <div class="form-group col-md-6">
+            @endif
+
+            <div class="form-row">
+                @if ($content_type === Post::CONTENT_TYPE_ARTICLE)
+                    <div class="form-group col-md-6">
+                        <label for="thumbnail">Post Thumbnail</label>
+                        <input type="file" id="thumbnail" class="form-control-file @error('thumbnail') is-invalid @enderror" wire:model="thumbnail" accept="image/*">
+                        @error('thumbnail')
+                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                        @enderror
+                        <div class="mt-3">
+                            @if ($thumbnail)
+                                <p class="text-muted small mb-2">Preview:</p>
+                                <img src="{{ $thumbnail->temporaryUrl() }}" alt="Thumbnail preview" class="img-thumbnail" style="max-height: 180px;">
+                            @elseif ($existingThumbnail)
+                                <p class="text-muted small mb-2">Current thumbnail:</p>
+                                <div class="d-flex align-items-center gap-3">
+                                    <img src="{{ asset('storage/' . $existingThumbnail) }}" alt="Current thumbnail" class="img-thumbnail" style="max-height: 180px;">
+                                    <button type="button" class="btn btn-sm btn-outline-danger" wire:click="removeExistingThumbnail">Remove</button>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+                @endif
+                <div class="form-group {{ $content_type === Post::CONTENT_TYPE_ARTICLE ? 'col-md-6' : 'col-12' }}">
                     <label>Post Options</label>
                     <div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" id="isFeatured" wire:model.defer="is_featured">


### PR DESCRIPTION
## Summary
- hide the post description and thumbnail inputs when the content type is set to video while keeping post options visible
- make the post description field optional for video content so validation matches the updated form behaviour

## Testing
- php artisan test *(fails: missing Composer dependencies due to restricted GitHub downloads)*

------
https://chatgpt.com/codex/tasks/task_b_68e025713410832e83a48c079345cb3c