### PR TITLE
Add fallback thumbnails for video posts

### DIFF
--- a/app/Http/Controllers/Frontend/PostController.php
+++ b/app/Http/Controllers/Frontend/PostController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\GeneralSetting;
 use App\Models\Post;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Storage;
 
 class PostController extends Controller
 {
@@ -16,7 +15,7 @@ class PostController extends Controller
 
         $settings = $this->settings();
 
-        $image = $post->thumbnail_path ? Storage::url($post->thumbnail_path) : null;
+        $image = $post->thumbnail_url;
 
         $seo = [
             'title' => $post->meta_title ?: $post->title,


### PR DESCRIPTION
## Summary
- provide a computed thumbnail URL for video posts when no local image is stored
- update the frontend post controller SEO image to use the computed thumbnail attribute

## Testing
- php artisan test *(fails: vendor directory is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e029e58a48832e801300c65d8aec82