### PR TITLE
Add media library management tooling

### DIFF
--- a/app/Http/Controllers/Admin/MediaLibraryController.php
+++ b/app/Http/Controllers/Admin/MediaLibraryController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Contracts\View\View;
+
+class MediaLibraryController extends Controller
+{
+    public function __invoke(): View
+    {
+        return view('back.pages.media.library', [
+            'pageTitle' => 'Media Library',
+        ]);
+    }
+}

--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -1,0 +1,442 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\MediaItem;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use Livewire\WithPagination;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class MediaLibrary extends Component
+{
+    use WithFileUploads;
+    use WithPagination;
+
+    protected $paginationTheme = 'bootstrap';
+
+    public string $viewMode = 'grid';
+    public string $search = '';
+    public string $typeFilter = 'all';
+    public string $sortDirection = 'desc';
+    public int $perPage = 20;
+
+    /**
+     * @var array<int, \Livewire\TemporaryUploadedFile>
+     */
+    public array $uploads = [];
+
+    public ?int $editingId = null;
+    public string $editingAltText = '';
+    public string $editingCaption = '';
+    public ?int $resizeWidth = null;
+    public ?int $resizeHeight = null;
+
+    protected $queryString = [
+        'viewMode' => ['except' => 'grid'],
+        'typeFilter' => ['except' => 'all'],
+        'search' => ['except' => ''],
+    ];
+
+    protected $rules = [
+        'uploads.*' => 'file|max:15360', // 15 MB
+    ];
+
+    protected $messages = [
+        'uploads.*.max' => 'Each file must be 15MB or less.',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->search = trim($this->search);
+    }
+
+    public function updatingTypeFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingSortDirection(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedViewMode($value): void
+    {
+        if (! in_array($value, ['grid', 'list'], true)) {
+            $this->viewMode = 'grid';
+        }
+    }
+
+    public function updatedUploads(): void
+    {
+        $this->handleUploads();
+    }
+
+    public function setViewMode(string $mode): void
+    {
+        $this->viewMode = in_array($mode, ['grid', 'list'], true) ? $mode : 'grid';
+    }
+
+    public function setSortDirection(string $direction): void
+    {
+        $this->sortDirection = $direction === 'asc' ? 'asc' : 'desc';
+    }
+
+    public function setTypeFilter(string $filter): void
+    {
+        $allowed = [
+            'all',
+            MediaItem::TYPE_IMAGE,
+            MediaItem::TYPE_VIDEO,
+            MediaItem::TYPE_AUDIO,
+            MediaItem::TYPE_DOCUMENT,
+            MediaItem::TYPE_ARCHIVE,
+            MediaItem::TYPE_OTHER,
+        ];
+
+        $this->typeFilter = in_array($filter, $allowed, true) ? $filter : 'all';
+    }
+
+    public function startEditing(int $mediaId): void
+    {
+        if (Auth::user()->cannot('media.edit')) {
+            $this->dispatch('showToastr', type: 'error', message: 'You do not have permission to edit media.');
+            return;
+        }
+
+        $media = MediaItem::findOrFail($mediaId);
+
+        $this->editingId = $media->id;
+        $this->editingAltText = (string) ($media->alt_text ?? '');
+        $this->editingCaption = (string) ($media->caption ?? '');
+        $this->resizeWidth = $media->width;
+        $this->resizeHeight = $media->height;
+
+        $this->dispatch('openMediaEditor', [
+            'id' => $media->id,
+            'url' => $this->resolveUrl($media),
+            'isImage' => $media->type === MediaItem::TYPE_IMAGE,
+            'width' => $media->width,
+            'height' => $media->height,
+            'altText' => $this->editingAltText,
+            'caption' => $this->editingCaption,
+            'mimeType' => $media->mime_type,
+        ]);
+    }
+
+    public function deleteMedia(int $mediaId): void
+    {
+        if (Auth::user()->cannot('media.delete')) {
+            $this->dispatch('showToastr', type: 'error', message: 'You do not have permission to delete media.');
+            return;
+        }
+
+        $media = MediaItem::findOrFail($mediaId);
+
+        $disk = Storage::disk($media->disk);
+        if ($disk->exists($media->path)) {
+            $disk->delete($media->path);
+        }
+
+        $media->delete();
+        $this->dispatch('showToastr', type: 'success', message: 'Media item removed successfully.');
+        $this->resetPage();
+    }
+
+    #[On('mediaEditorSave')]
+    public function saveMediaEditor(array $payload): void
+    {
+        $mediaId = (int) Arr::get($payload, 'id');
+        if (! $mediaId) {
+            return;
+        }
+
+        if (Auth::user()->cannot('media.edit')) {
+            $this->dispatch('showToastr', type: 'error', message: 'You do not have permission to edit media.');
+            return;
+        }
+
+        $media = MediaItem::findOrFail($mediaId);
+        $altText = trim((string) Arr::get($payload, 'altText', ''));
+        $caption = trim((string) Arr::get($payload, 'caption', ''));
+
+        $media->update([
+            'alt_text' => $altText !== '' ? $altText : null,
+            'caption' => $caption !== '' ? $caption : null,
+        ]);
+
+        if ($media->type === MediaItem::TYPE_IMAGE) {
+            $cropData = Arr::get($payload, 'crop');
+            $resizeData = Arr::get($payload, 'resize');
+            $this->manipulateImage($media, $cropData, $resizeData);
+        }
+
+        $this->dispatch('showToastr', type: 'success', message: 'Media details updated successfully.');
+        $this->dispatch('mediaEditorClosed');
+        $this->resetEditing();
+    }
+
+    public function render()
+    {
+        $mediaItems = MediaItem::query()
+            ->when($this->typeFilter !== 'all', function ($query) {
+                $query->where('type', $this->typeFilter);
+            })
+            ->when($this->search !== '', function ($query) {
+                $searchTerm = '%'.$this->search.'%';
+                $query->where(function ($nested) use ($searchTerm) {
+                    $nested->where('original_name', 'like', $searchTerm)
+                        ->orWhere('file_name', 'like', $searchTerm)
+                        ->orWhere('alt_text', 'like', $searchTerm)
+                        ->orWhere('caption', 'like', $searchTerm);
+                });
+            })
+            ->orderBy('created_at', $this->sortDirection === 'asc' ? 'asc' : 'desc')
+            ->paginate($this->perPage);
+
+        return view('livewire.admin.media-library', [
+            'mediaItems' => $mediaItems,
+        ]);
+    }
+
+    #[Computed]
+    public function libraryStats(): array
+    {
+        $totals = MediaItem::selectRaw('type, COUNT(*) as aggregate')
+            ->groupBy('type')
+            ->pluck('aggregate', 'type')
+            ->all();
+
+        $totalCount = array_sum($totals);
+
+        return [
+            'total' => $totalCount,
+            'images' => $totals[MediaItem::TYPE_IMAGE] ?? 0,
+            'videos' => $totals[MediaItem::TYPE_VIDEO] ?? 0,
+            'documents' => $totals[MediaItem::TYPE_DOCUMENT] ?? 0,
+            'audio' => $totals[MediaItem::TYPE_AUDIO] ?? 0,
+            'archives' => $totals[MediaItem::TYPE_ARCHIVE] ?? 0,
+            'other' => $totals[MediaItem::TYPE_OTHER] ?? 0,
+        ];
+    }
+
+    protected function handleUploads(): void
+    {
+        if (empty($this->uploads)) {
+            return;
+        }
+
+        if (Auth::user()->cannot('media.create')) {
+            $this->dispatch('showToastr', type: 'error', message: 'You do not have permission to upload media.');
+            $this->uploads = [];
+            return;
+        }
+
+        $this->validate();
+
+        foreach ($this->uploads as $file) {
+            $this->storeUploadedFile($file);
+        }
+
+        $this->dispatch('showToastr', type: 'success', message: 'Media uploaded successfully.');
+        $this->uploads = [];
+        $this->resetPage();
+    }
+
+    protected function storeUploadedFile(UploadedFile $file): void
+    {
+        $disk = 'public';
+        $originalName = $file->getClientOriginalName();
+        $extension = $file->getClientOriginalExtension();
+        $fileName = Str::uuid()->toString().($extension ? '.'.$extension : '');
+        $path = $file->storeAs('media-library', $fileName, $disk);
+
+        $mimeType = $file->getClientMimeType();
+        $size = $file->getSize() ?: 0;
+        $type = $this->determineType($mimeType);
+
+        $width = null;
+        $height = null;
+        if ($type === MediaItem::TYPE_IMAGE) {
+            $dimensions = @getimagesize($file->getRealPath());
+            if (is_array($dimensions)) {
+                $width = $dimensions[0] ?? null;
+                $height = $dimensions[1] ?? null;
+            }
+        }
+
+        MediaItem::create([
+            'disk' => $disk,
+            'path' => $path,
+            'file_name' => $fileName,
+            'original_name' => $originalName,
+            'mime_type' => $mimeType,
+            'type' => $type,
+            'size' => $size,
+            'width' => $width,
+            'height' => $height,
+        ]);
+    }
+
+    protected function determineType(?string $mime): string
+    {
+        if (! $mime) {
+            return MediaItem::TYPE_OTHER;
+        }
+
+        if (str_starts_with($mime, 'image/')) {
+            return MediaItem::TYPE_IMAGE;
+        }
+
+        if (str_starts_with($mime, 'video/')) {
+            return MediaItem::TYPE_VIDEO;
+        }
+
+        if (str_starts_with($mime, 'audio/')) {
+            return MediaItem::TYPE_AUDIO;
+        }
+
+        if (Str::contains($mime, ['pdf', 'msword', 'spreadsheet', 'presentation']) ||
+            str_contains($mime, 'text/')) {
+            return MediaItem::TYPE_DOCUMENT;
+        }
+
+        if (Str::contains($mime, ['zip', 'rar', 'tar', 'gzip'])) {
+            return MediaItem::TYPE_ARCHIVE;
+        }
+
+        return MediaItem::TYPE_OTHER;
+    }
+
+    protected function manipulateImage(MediaItem $media, $cropData, $resizeData): void
+    {
+        $disk = Storage::disk($media->disk);
+        if (! $disk->exists($media->path)) {
+            return;
+        }
+
+        $absolutePath = $disk->path($media->path);
+        $imageResource = $this->createImageResource($absolutePath, $media->mime_type);
+
+        if (! $imageResource) {
+            return;
+        }
+
+        if (is_array($cropData)) {
+            $cropArray = [
+                'x' => max(0, (int) round(Arr::get($cropData, 'x', 0))),
+                'y' => max(0, (int) round(Arr::get($cropData, 'y', 0))),
+                'width' => max(1, (int) round(Arr::get($cropData, 'width', imagesx($imageResource)))),
+                'height' => max(1, (int) round(Arr::get($cropData, 'height', imagesy($imageResource)))),
+            ];
+
+            $cropped = imagecrop($imageResource, $cropArray);
+            if ($cropped !== false) {
+                imagedestroy($imageResource);
+                $imageResource = $cropped;
+            }
+        }
+
+        if (is_array($resizeData)) {
+            $targetWidth = (int) Arr::get($resizeData, 'width', 0);
+            $targetHeight = (int) Arr::get($resizeData, 'height', 0);
+
+            if ($targetWidth > 0 && $targetHeight > 0) {
+                $resized = imagecreatetruecolor($targetWidth, $targetHeight);
+
+                if (in_array($media->mime_type, ['image/png', 'image/webp'], true)) {
+                    imagealphablending($resized, false);
+                    imagesavealpha($resized, true);
+                }
+
+                imagecopyresampled(
+                    $resized,
+                    $imageResource,
+                    0,
+                    0,
+                    0,
+                    0,
+                    $targetWidth,
+                    $targetHeight,
+                    imagesx($imageResource),
+                    imagesy($imageResource)
+                );
+
+                imagedestroy($imageResource);
+                $imageResource = $resized;
+            }
+        }
+
+        $this->writeImageResource($imageResource, $absolutePath, $media->mime_type);
+        imagedestroy($imageResource);
+
+        clearstatcache(true, $absolutePath);
+        $dimensions = @getimagesize($absolutePath);
+
+        $media->update([
+            'width' => $dimensions[0] ?? null,
+            'height' => $dimensions[1] ?? null,
+            'size' => $disk->size($media->path),
+        ]);
+    }
+
+    protected function createImageResource(string $path, ?string $mime)
+    {
+        return match ($mime) {
+            'image/jpeg', 'image/jpg' => @imagecreatefromjpeg($path),
+            'image/png' => @imagecreatefrompng($path),
+            'image/gif' => @imagecreatefromgif($path),
+            'image/webp' => function_exists('imagecreatefromwebp') ? @imagecreatefromwebp($path) : null,
+            default => @imagecreatefromstring((string) @file_get_contents($path)),
+        };
+    }
+
+    protected function writeImageResource($image, string $path, ?string $mime): void
+    {
+        switch ($mime) {
+            case 'image/png':
+                imagepng($image, $path);
+                break;
+            case 'image/gif':
+                imagegif($image, $path);
+                break;
+            case 'image/webp':
+                if (function_exists('imagewebp')) {
+                    imagewebp($image, $path, 90);
+                    break;
+                }
+                // fallthrough
+            case 'image/jpeg':
+            case 'image/jpg':
+            default:
+                imagejpeg($image, $path, 90);
+                break;
+        }
+    }
+
+    protected function resetEditing(): void
+    {
+        $this->editingId = null;
+        $this->editingAltText = '';
+        $this->editingCaption = '';
+        $this->resizeWidth = null;
+        $this->resizeHeight = null;
+    }
+
+    protected function resolveUrl(MediaItem $media): string
+    {
+        return $media->url();
+    }
+}

--- a/app/Models/MediaItem.php
+++ b/app/Models/MediaItem.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+class MediaItem extends Model
+{
+    use HasFactory;
+
+    public const TYPE_IMAGE = 'image';
+    public const TYPE_VIDEO = 'video';
+    public const TYPE_AUDIO = 'audio';
+    public const TYPE_DOCUMENT = 'document';
+    public const TYPE_ARCHIVE = 'archive';
+    public const TYPE_OTHER = 'file';
+
+    protected $fillable = [
+        'disk',
+        'path',
+        'file_name',
+        'original_name',
+        'mime_type',
+        'type',
+        'size',
+        'width',
+        'height',
+        'alt_text',
+        'caption',
+        'meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
+    public function url(): string
+    {
+        return Storage::disk($this->disk)->url($this->path);
+    }
+
+    public function sizeForHumans(int $precision = 2): string
+    {
+        $bytes = (int) $this->size;
+        if ($bytes <= 0) {
+            return '0 B';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $pow = min((int) floor(log($bytes, 1024)), count($units) - 1);
+        $value = $bytes / (1024 ** $pow);
+
+        return sprintf('%s %s', number_format($value, $precision), $units[$pow]);
+    }
+}

--- a/database/migrations/2025_10_08_000000_create_media_items_table.php
+++ b/database/migrations/2025_10_08_000000_create_media_items_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media_items', function (Blueprint $table) {
+            $table->id();
+            $table->string('disk')->default('public');
+            $table->string('path');
+            $table->string('file_name');
+            $table->string('original_name');
+            $table->string('mime_type')->nullable();
+            $table->string('type')->default('file');
+            $table->unsignedBigInteger('size')->default(0);
+            $table->unsignedInteger('width')->nullable();
+            $table->unsignedInteger('height')->nullable();
+            $table->string('alt_text')->nullable();
+            $table->text('caption')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media_items');
+    }
+};

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -47,6 +47,15 @@ class RolePermissionSeeder extends Seeder
                 ]
             ],
             [
+                'group_name' => 'Media Library',
+                'permissions' => [
+                    'media.view',
+                    'media.create',
+                    'media.edit',
+                    'media.delete',
+                ]
+            ],
+            [
                 'group_name' => 'Posts',
                 'permissions' => [
                     'post.view',

--- a/resources/views/back/pages/media/library.blade.php
+++ b/resources/views/back/pages/media/library.blade.php
@@ -1,0 +1,16 @@
+@extends('back.layout.pages-layout')
+@section('pageTitle', $pageTitle ?? 'Media Library')
+@section('content')
+    <header class="page-title-bar">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+            <div>
+                <h1 class="page-title">Media Library</h1>
+                <p class="text-muted mb-0">Manage images, videos, and documents used across the site.</p>
+            </div>
+        </div>
+    </header>
+
+    <div class="page-section">
+        <livewire:admin.media-library />
+    </div>
+@endsection

--- a/resources/views/back/partials/sidebar.blade.php
+++ b/resources/views/back/partials/sidebar.blade.php
@@ -60,6 +60,12 @@
                     </li>
                     @endcan
 
+                    @can('media.view')
+                    <li class="menu-item {{ request()->routeIs('admin.media-library.*') ? 'has-active' : '' }}">
+                        <a href="{{ route('admin.media-library.index') }}" class="menu-link"><span class="menu-icon fas fa-photo-video"></span> <span class="menu-text">Media Library</span></a>
+                    </li>
+                    @endcan
+
                     <li class="menu-item has-child {{ request()->routeIs('admin.profile') || request()->routeIs('admin.users.*') || request()->routeIs('admin.roles.*') ||  request()->routeIs('admin.permissions.*')? 'has-active' : '' }}">
                         <a href="#" class="menu-link"><span class="menu-icon oi oi-person"></span> <span class="menu-text">User</span></a>
                         <ul class="menu">

--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -1,0 +1,483 @@
+@php
+    use App\Models\MediaItem;
+    use Illuminate\Support\Str;
+@endphp
+
+<div class="media-library" x-data="mediaLibraryComponent()" x-init="init()">
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="row g-3 align-items-center">
+                <div class="col-xl-3 col-lg-4">
+                    <div class="text-muted text-uppercase small fw-semibold">Library Overview</div>
+                    <div class="h4 mb-0">{{ $this->libraryStats['total'] ?? 0 }} Files</div>
+                    <div class="small text-muted">Images {{ $this->libraryStats['images'] ?? 0 }} · Videos {{ $this->libraryStats['videos'] ?? 0 }} · Documents {{ $this->libraryStats['documents'] ?? 0 }}</div>
+                </div>
+                <div class="col-xl-3 col-lg-4">
+                    <label for="media-search" class="form-label mb-1 text-muted small text-uppercase">Search</label>
+                    <div class="input-group">
+                        <span class="input-group-text bg-white border-right-0"><i class="fas fa-search"></i></span>
+                        <input id="media-search" type="search" class="form-control border-left-0" placeholder="Search media..." wire:model.live.debounce.500ms="search">
+                    </div>
+                </div>
+                <div class="col-xl-3 col-lg-4">
+                    <label for="media-type-filter" class="form-label mb-1 text-muted small text-uppercase">Filter</label>
+                    <select id="media-type-filter" class="form-select" wire:change="setTypeFilter($event.target.value)">
+                        <option value="all" @selected($typeFilter === 'all')>All files</option>
+                        <option value="{{ MediaItem::TYPE_IMAGE }}" @selected($typeFilter === MediaItem::TYPE_IMAGE)>Images</option>
+                        <option value="{{ MediaItem::TYPE_VIDEO }}" @selected($typeFilter === MediaItem::TYPE_VIDEO)>Videos</option>
+                        <option value="{{ MediaItem::TYPE_DOCUMENT }}" @selected($typeFilter === MediaItem::TYPE_DOCUMENT)>Documents</option>
+                        <option value="{{ MediaItem::TYPE_AUDIO }}" @selected($typeFilter === MediaItem::TYPE_AUDIO)>Audio</option>
+                        <option value="{{ MediaItem::TYPE_ARCHIVE }}" @selected($typeFilter === MediaItem::TYPE_ARCHIVE)>Archives</option>
+                        <option value="{{ MediaItem::TYPE_OTHER }}" @selected($typeFilter === MediaItem::TYPE_OTHER)>Other</option>
+                    </select>
+                </div>
+                <div class="col-xl-3 col-lg-12">
+                    <label class="form-label mb-1 text-muted small text-uppercase">View</label>
+                    <div class="d-flex flex-wrap gap-2">
+                        <div class="btn-group" role="group">
+                            <button type="button" class="btn btn-outline-secondary @if($viewMode === 'grid') active @endif" wire:click="setViewMode('grid')"><i class="fas fa-th-large me-1"></i> Grid</button>
+                            <button type="button" class="btn btn-outline-secondary @if($viewMode === 'list') active @endif" wire:click="setViewMode('list')"><i class="fas fa-list me-1"></i> List</button>
+                        </div>
+                        <div class="btn-group" role="group">
+                            <button type="button" class="btn btn-outline-secondary @if($sortDirection === 'desc') active @endif" wire:click="setSortDirection('desc')" title="Newest first"><i class="fas fa-sort-amount-down"></i></button>
+                            <button type="button" class="btn btn-outline-secondary @if($sortDirection === 'asc') active @endif" wire:click="setSortDirection('asc')" title="Oldest first"><i class="fas fa-sort-amount-up"></i></button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="border border-dashed rounded-3 p-4 position-relative text-center upload-drop-zone" :class="{ 'is-dropping': dropping }"
+                x-on:dragover.prevent="dropping = true" x-on:dragleave.prevent="dropping = false" x-on:drop.prevent="handleDrop($event)">
+                <input type="file" multiple class="position-absolute w-100 h-100 top-0 start-0 opacity-0" x-ref="fileInput" wire:model="uploads">
+                <div class="py-5">
+                    <div class="display-6 text-primary mb-2"><i class="fas fa-cloud-upload-alt"></i></div>
+                    <h5 class="mb-1">Drop files here or click to upload</h5>
+                    <p class="text-muted mb-0">You can upload multiple images, videos or documents up to 15MB each.</p>
+                </div>
+            </div>
+            <div class="mt-3" wire:loading.flex wire:target="uploads">
+                <span class="spinner-border spinner-border-sm me-2" role="status"></span> Uploading files...
+            </div>
+            @error('uploads.*')
+                <div class="alert alert-danger mt-3">{{ $message }}</div>
+            @enderror
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            @if ($mediaItems->isEmpty())
+                <div class="p-5 text-center text-muted">
+                    <i class="fas fa-images fa-2x mb-3"></i>
+                    <h5 class="mb-1">No media files found</h5>
+                    <p class="mb-0">Upload new files to build your media library.</p>
+                </div>
+            @else
+                @if ($viewMode === 'list')
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th style="width: 60px"></th>
+                                    <th>Name</th>
+                                    <th>Details</th>
+                                    <th>Alt Text</th>
+                                    <th>Caption</th>
+                                    <th class="text-end">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($mediaItems as $media)
+                                    <tr wire:key="media-row-{{ $media->id }}">
+                                        <td>
+                                            @if ($media->type === MediaItem::TYPE_IMAGE)
+                                                <img src="{{ $media->url() }}" alt="{{ $media->original_name }}" class="rounded" style="width:48px;height:48px;object-fit:cover;">
+                                            @else
+                                                <span class="badge bg-secondary text-uppercase">{{ strtoupper($media->type) }}</span>
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <div class="fw-semibold text-truncate" style="max-width: 220px" title="{{ $media->original_name }}">{{ $media->original_name }}</div>
+                                            <div class="text-muted small">{{ $media->file_name }}</div>
+                                        </td>
+                                        <td>
+                                            <div class="text-muted small">
+                                                {{ strtoupper(pathinfo($media->file_name, PATHINFO_EXTENSION)) }} · {{ $media->sizeForHumans(1) }}
+                                                @if($media->width && $media->height)
+                                                    · {{ $media->width }}×{{ $media->height }}
+                                                @endif
+                                            </div>
+                                        </td>
+                                        <td class="small text-muted">{{ $media->alt_text ?? '—' }}</td>
+                                        <td class="small text-muted">{{ $media->caption ? Str::limit($media->caption, 40) : '—' }}</td>
+                                        <td class="text-end">
+                                            <div class="btn-group btn-group-sm" role="group">
+                                                <button type="button" class="btn btn-outline-primary" wire:click="startEditing({{ $media->id }})">Edit</button>
+                                                <button type="button" class="btn btn-outline-danger" x-on:click.prevent="confirmDelete({{ $media->id }})">Delete</button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @else
+                    <div class="row g-3 p-3">
+                        @foreach ($mediaItems as $media)
+                            <div class="col-xl-3 col-lg-4 col-md-6" wire:key="media-card-{{ $media->id }}">
+                                <div class="card h-100 border-0 shadow-sm">
+                                    <div class="ratio ratio-4x3 bg-light rounded-top position-relative overflow-hidden">
+                                        @if ($media->type === MediaItem::TYPE_IMAGE)
+                                            <img src="{{ $media->url() }}" alt="{{ $media->original_name }}" class="w-100 h-100" style="object-fit: cover;">
+                                        @else
+                                            <div class="d-flex flex-column align-items-center justify-content-center h-100 text-muted">
+                                                <i class="fas fa-file fa-2x mb-2"></i>
+                                                <span class="badge bg-dark text-uppercase">{{ strtoupper($media->type) }}</span>
+                                            </div>
+                                        @endif
+                                    </div>
+                                    <div class="card-body">
+                                        <h6 class="card-title text-truncate" title="{{ $media->original_name }}">{{ $media->original_name }}</h6>
+                                        <p class="small text-muted mb-3">{{ strtoupper(pathinfo($media->file_name, PATHINFO_EXTENSION)) }} · {{ $media->sizeForHumans(1) }} @if($media->width && $media->height) · {{ $media->width }}×{{ $media->height }} @endif</p>
+                                        <div class="d-flex gap-2">
+                                            <button type="button" class="btn btn-outline-primary btn-sm flex-grow-1" wire:click="startEditing({{ $media->id }})"><i class="fas fa-edit me-1"></i> Edit</button>
+                                            <button type="button" class="btn btn-outline-danger btn-sm" x-on:click.prevent="confirmDelete({{ $media->id }})"><i class="fas fa-trash"></i></button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+
+                <div class="p-3 border-top">
+                    {{ $mediaItems->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <div class="modal fade" id="mediaEditorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Media</h5>
+                    <button type="button" class="close" data-bs-dismiss="modal" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="row g-4">
+                        <div class="col-lg-8">
+                            <div class="bg-light rounded p-2 position-relative" style="min-height: 360px;">
+                                <img id="media-editor-image" class="img-fluid rounded w-100 d-none" alt="Editable preview">
+                                <div id="media-editor-non-image" class="d-none h-100 w-100 d-flex align-items-center justify-content-center flex-column text-muted">
+                                    <i class="fas fa-file fa-3x mb-3"></i>
+                                    <p class="mb-0">Cropping &amp; resizing are available for images only.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-lg-4">
+                            <div class="mb-3">
+                                <label class="form-label">Alt Text</label>
+                                <input type="text" class="form-control" x-ref="altInput">
+                                <small class="text-muted">Used for accessibility and SEO.</small>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Caption</label>
+                                <textarea class="form-control" rows="3" x-ref="captionInput"></textarea>
+                                <small class="text-muted">Optional description displayed with the media.</small>
+                            </div>
+                            <template x-if="isImage">
+                                <div class="border rounded p-3 mb-3">
+                                    <h6 class="fw-semibold">Resize</h6>
+                                    <div class="row g-2 align-items-center">
+                                        <div class="col">
+                                            <label class="form-label small text-muted">Width (px)</label>
+                                            <input type="number" min="1" class="form-control form-control-sm" x-model.number="resizeWidth">
+                                        </div>
+                                        <div class="col">
+                                            <label class="form-label small text-muted">Height (px)</label>
+                                            <input type="number" min="1" class="form-control form-control-sm" x-model.number="resizeHeight">
+                                        </div>
+                                    </div>
+                                    <div class="form-check mt-2">
+                                        <input class="form-check-input" type="checkbox" id="media-editor-lock-ratio" x-model="lockRatio">
+                                        <label class="form-check-label" for="media-editor-lock-ratio">Lock aspect ratio</label>
+                                    </div>
+                                    <button type="button" class="btn btn-link btn-sm px-0" x-on:click="resetCrop()">Reset crop</button>
+                                </div>
+                            </template>
+                            <div class="small text-muted">
+                                <div><strong>File:</strong> <span x-text="fileName"></span></div>
+                                <div><strong>Type:</strong> <span x-text="mimeType"></span></div>
+                                <div><strong>Dimensions:</strong> <span x-text="dimensions"></span></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary" x-on:click="saveChanges()">Save changes</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@once
+    @push('styles')
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cropperjs@1.6.2/dist/cropper.min.css" integrity="sha384-lU3u69ptYPu5GYEfzKGUSf02Pp3t/AEUReyX4OA974odKwpcWLfSomKs6S38QGlw" crossorigin="anonymous">
+        <style>
+            .upload-drop-zone {
+                transition: all .2s ease-in-out;
+                cursor: pointer;
+            }
+
+            .upload-drop-zone.is-dropping {
+                background: rgba(59, 130, 246, 0.08);
+                border-color: rgba(59, 130, 246, 0.6);
+            }
+
+            .upload-drop-zone input[type="file"] {
+                cursor: pointer;
+            }
+        </style>
+    @endpush
+
+    @push('scripts')
+        <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.6.2/dist/cropper.min.js" integrity="sha384-/RkNvztNFVQVwKP1HjqCOUMIqFZ3VAbwY/jGj33jjXNMTvEihQ/HVbUaz2YsmiPg" crossorigin="anonymous"></script>
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('mediaLibraryComponent', () => ({
+                    dropping: false,
+                    cropper: null,
+                    isImage: false,
+                    lockRatio: true,
+                    resizeWidth: null,
+                    resizeHeight: null,
+                    originalWidth: null,
+                    originalHeight: null,
+                    fileName: '',
+                    mimeType: '',
+                    mediaId: null,
+                    dimensions: '—',
+                    suppressRatioUpdate: false,
+                    init() {
+                        this.$watch('resizeWidth', (value) => {
+                            if (!this.isImage || !this.lockRatio || this.suppressRatioUpdate) {
+                                return;
+                            }
+
+                            if (!value || !this.originalWidth || !this.originalHeight) {
+                                return;
+                            }
+
+                            const ratio = this.originalHeight / this.originalWidth;
+                            this.suppressRatioUpdate = true;
+                            this.resizeHeight = Math.round(value * ratio);
+                            if (this.cropper) {
+                                this.cropper.setData({ width: value, height: this.resizeHeight });
+                            }
+                            this.dimensions = `${Math.round(value)}×${Math.round(this.resizeHeight || 0)}`;
+                            this.suppressRatioUpdate = false;
+                        });
+
+                        this.$watch('resizeHeight', (value) => {
+                            if (!this.isImage || !this.lockRatio || this.suppressRatioUpdate) {
+                                return;
+                            }
+
+                            if (!value || !this.originalWidth || !this.originalHeight) {
+                                return;
+                            }
+
+                            const ratio = this.originalWidth / this.originalHeight;
+                            this.suppressRatioUpdate = true;
+                            this.resizeWidth = Math.round(value * ratio);
+                            if (this.cropper) {
+                                this.cropper.setData({ width: this.resizeWidth, height: value });
+                            }
+                            this.dimensions = `${Math.round(this.resizeWidth || 0)}×${Math.round(value)}`;
+                            this.suppressRatioUpdate = false;
+                        });
+
+                        window.addEventListener('openMediaEditor', (event) => {
+                            const detail = event.detail || {};
+                            this.mediaId = detail.id || null;
+                            this.isImage = Boolean(detail.isImage);
+                            this.fileName = detail.url ? detail.url.split('/').pop() : '';
+                            this.mimeType = detail.mimeType || '';
+                            this.resizeWidth = detail.width || null;
+                            this.resizeHeight = detail.height || null;
+                            this.originalWidth = detail.width || null;
+                            this.originalHeight = detail.height || null;
+                            this.dimensions = detail.width && detail.height ? `${detail.width}×${detail.height}` : '—';
+
+                            if (this.$refs.altInput) {
+                                this.$refs.altInput.value = detail.altText || '';
+                            }
+
+                            if (this.$refs.captionInput) {
+                                this.$refs.captionInput.value = detail.caption || '';
+                            }
+
+                            const modalEl = document.getElementById('mediaEditorModal');
+                            let modalInstance = null;
+                            if (modalEl) {
+                                if (window.bootstrap && window.bootstrap.Modal) {
+                                    modalInstance = new bootstrap.Modal(modalEl);
+                                    modalInstance.show();
+                                } else if (window.jQuery) {
+                                    window.jQuery(modalEl).modal('show');
+                                }
+                            }
+
+                            this.setupEditor(detail);
+                        });
+
+                        window.addEventListener('mediaEditorClosed', () => {
+                            const modalEl = document.getElementById('mediaEditorModal');
+                            if (modalEl) {
+                                if (window.bootstrap && window.bootstrap.Modal) {
+                                    const instance = bootstrap.Modal.getInstance(modalEl);
+                                    if (instance) {
+                                        instance.hide();
+                                    }
+                                } else if (window.jQuery) {
+                                    window.jQuery(modalEl).modal('hide');
+                                }
+                            }
+                            this.destroyCropper();
+                        });
+                    },
+                    handleDrop(event) {
+                        this.dropping = false;
+                        const files = event.dataTransfer?.files;
+                        if (files && files.length) {
+                            this.$refs.fileInput.files = files;
+                            this.$refs.fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    },
+                    setupEditor(detail) {
+                        const imageEl = document.getElementById('media-editor-image');
+                        const fallbackEl = document.getElementById('media-editor-non-image');
+
+                        this.destroyCropper();
+
+                        if (!this.isImage) {
+                            if (imageEl) {
+                                imageEl.classList.add('d-none');
+                            }
+                            if (fallbackEl) {
+                                fallbackEl.classList.remove('d-none');
+                            }
+                            return;
+                        }
+
+                        if (fallbackEl) {
+                            fallbackEl.classList.add('d-none');
+                        }
+
+                        if (imageEl) {
+                            imageEl.classList.remove('d-none');
+                            imageEl.src = detail.url ? `${detail.url}?t=${Date.now()}` : '';
+                            imageEl.onload = () => {
+                                this.originalWidth = imageEl.naturalWidth;
+                                this.originalHeight = imageEl.naturalHeight;
+                                this.resizeWidth = imageEl.naturalWidth;
+                                this.resizeHeight = imageEl.naturalHeight;
+                                this.dimensions = `${imageEl.naturalWidth}×${imageEl.naturalHeight}`;
+                                this.initCropper(imageEl);
+                            };
+                        }
+                    },
+                    initCropper(imageEl) {
+                        this.cropper = new Cropper(imageEl, {
+                            viewMode: 1,
+                            autoCropArea: 1,
+                            responsive: true,
+                            checkOrientation: false,
+                            ready: () => {
+                                const data = this.cropper.getData();
+                                this.suppressRatioUpdate = true;
+                                this.resizeWidth = Math.round(data.width);
+                                this.resizeHeight = Math.round(data.height);
+                                this.dimensions = `${this.resizeWidth}×${this.resizeHeight}`;
+                                this.suppressRatioUpdate = false;
+                            },
+                            crop: () => {
+                                if (!this.cropper) {
+                                    return;
+                                }
+                                const data = this.cropper.getData();
+                                this.suppressRatioUpdate = true;
+                                this.resizeWidth = Math.round(data.width);
+                                this.resizeHeight = Math.round(data.height);
+                                this.dimensions = `${this.resizeWidth}×${this.resizeHeight}`;
+                                this.suppressRatioUpdate = false;
+                            }
+                        });
+                    },
+                    destroyCropper() {
+                        if (this.cropper) {
+                            this.cropper.destroy();
+                            this.cropper = null;
+                        }
+                    },
+                    resetCrop() {
+                        if (this.cropper) {
+                            this.cropper.reset();
+                            const data = this.cropper.getData();
+                            this.suppressRatioUpdate = true;
+                            this.resizeWidth = Math.round(data.width);
+                            this.resizeHeight = Math.round(data.height);
+                            this.dimensions = `${this.resizeWidth}×${this.resizeHeight}`;
+                            this.suppressRatioUpdate = false;
+                        }
+                    },
+                    saveChanges() {
+                        const altText = this.$refs.altInput ? this.$refs.altInput.value : '';
+                        const caption = this.$refs.captionInput ? this.$refs.captionInput.value : '';
+
+                        const payload = {
+                            id: this.mediaId,
+                            altText,
+                            caption,
+                            crop: null,
+                            resize: null,
+                        };
+
+                        if (this.isImage && this.cropper) {
+                            const data = this.cropper.getData(true);
+                            payload.crop = {
+                                x: data.x,
+                                y: data.y,
+                                width: data.width,
+                                height: data.height,
+                            };
+
+                            if (this.resizeWidth && this.resizeHeight) {
+                                payload.resize = {
+                                    width: Math.round(this.resizeWidth),
+                                    height: Math.round(this.resizeHeight),
+                                };
+                            }
+                        }
+
+                        Livewire.dispatch('mediaEditorSave', payload);
+                    },
+                    confirmDelete(id) {
+                        if (confirm('Are you sure you want to delete this media file?')) {
+                            this.$wire.call('deleteMedia', id);
+                        }
+                    }
+                }));
+            });
+        </script>
+    @endpush
+@endonce

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\PostController as AdminPostController;
 use App\Http\Controllers\Admin\PollController as AdminPollController;
+use App\Http\Controllers\Admin\MediaLibraryController;
 use App\Http\Controllers\Admin\SubCategoryController;
 use App\Http\Controllers\Admin\UserManagementController;
 use App\Http\Controllers\Admin\RoleController;
@@ -53,6 +54,9 @@ Route::prefix('admin')->name('admin.')->group(function () {
         Route::resource('categories', CategoryController::class)->except(['show']);
         Route::resource('subcategories', SubCategoryController::class)->except(['show']);
         Route::resource('posts', AdminPostController::class)->only(['index', 'create', 'edit']);
+        Route::get('media-library', MediaLibraryController::class)
+            ->name('media-library.index')
+            ->middleware('permission:media.view');
         Route::resource('polls', AdminPollController::class)->only(['index', 'create', 'edit']);
 
        Route::resource('roles', RoleController::class);


### PR DESCRIPTION
## Summary
- add a persistent `media_items` table and model plus seed permissions for media management
- build a Livewire-powered media library interface with drag-and-drop uploads, grid/list browsing, and Cropper.js-based editing tools
- expose the media library page in the admin area with navigation and routing

## Testing
- php artisan test *(fails: vendor/autoload.php missing because Composer install could not complete due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68e02dfc0098832e8cdd6e3d1d78314a