### PR TITLE
Handle optional payload for media editor event

### DIFF
--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -156,8 +156,12 @@ class MediaLibrary extends Component
     }
 
     #[On('mediaEditorSave')]
-    public function saveMediaEditor(array $payload): void
+    public function saveMediaEditor($payload = []): void
     {
+        if (! is_array($payload)) {
+            $payload = (array) $payload;
+        }
+
         $mediaId = (int) Arr::get($payload, 'id');
         if (! $mediaId) {
             return;


### PR DESCRIPTION
## Summary
- allow the media editor save handler to accept missing or non-array payloads
- cast incoming event data to an array before using Arr helpers so the editor can save alt text and captions without errors

## Testing
- php artisan test *(fails: vendor dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68e036515360832ea5cee6862bc44fea