### PR TITLE
Fix media editor payload to enable image editing controls

### DIFF
--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -124,16 +124,17 @@ class MediaLibrary extends Component
         $this->resizeWidth = $media->width;
         $this->resizeHeight = $media->height;
 
-        $this->dispatch('openMediaEditor', [
-            'id' => $media->id,
-            'url' => $this->resolveUrl($media),
-            'isImage' => $media->type === MediaItem::TYPE_IMAGE,
-            'width' => $media->width,
-            'height' => $media->height,
-            'altText' => $this->editingAltText,
-            'caption' => $this->editingCaption,
-            'mimeType' => $media->mime_type,
-        ]);
+        $this->dispatch(
+            'openMediaEditor',
+            id: $media->id,
+            url: $this->resolveUrl($media),
+            isImage: $media->type === MediaItem::TYPE_IMAGE,
+            width: $media->width,
+            height: $media->height,
+            altText: $this->editingAltText,
+            caption: $this->editingCaption,
+            mimeType: $media->mime_type,
+        );
     }
 
     public function deleteMedia(int $mediaId): void


### PR DESCRIPTION
## Summary
- send the media editor event payload as named arguments so Alpine receives the expected detail object

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68e038762a38832eb5153c9c62d79916