### PR TITLE
Delay media editor initialization until Alpine renders

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -337,7 +337,9 @@
                                 }
                             }
 
-                            this.setupEditor(detail);
+                            this.$nextTick(() => {
+                                this.setupEditor(detail);
+                            });
                         });
 
                         window.addEventListener('mediaEditorClosed', () => {


### PR DESCRIPTION
## Summary
- defer media editor setup until after Alpine completes DOM updates to ensure the preview image is ready for Cropper.js

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e039c39028832e9706d071d6a6ceaf