### PR TITLE
Fix media editor save action fallback

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -462,7 +462,30 @@
                             }
                         }
 
-                        Livewire.dispatch('mediaEditorSave', payload);
+                        const dispatched = (() => {
+                            if (this.$wire && typeof this.$wire.call === 'function') {
+                                this.$wire.call('saveMediaEditor', payload);
+                                return true;
+                            }
+
+                            if (typeof Livewire !== 'undefined') {
+                                if (typeof Livewire.dispatch === 'function') {
+                                    Livewire.dispatch('mediaEditorSave', payload);
+                                    return true;
+                                }
+
+                                if (typeof Livewire.emit === 'function') {
+                                    Livewire.emit('mediaEditorSave', payload);
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        })();
+
+                        if (!dispatched) {
+                            console.error('Unable to save media changes because Livewire is not available.');
+                        }
                     },
                     confirmDelete(id) {
                         if (confirm('Are you sure you want to delete this media file?')) {


### PR DESCRIPTION
## Summary
- ensure the media editor save button can call the Livewire action even when the global dispatcher is unavailable
- log a console error when Livewire cannot be reached so issues are easier to debug

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e03bcdb0b0832eaa3a28ce4c1d9220