### PR TITLE
Fix lingering media editor modal backdrop cleanup

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -349,11 +349,16 @@
                                     const instance = bootstrap.Modal.getInstance(modalEl);
                                     if (instance) {
                                         instance.hide();
+                                        instance.dispose();
                                     }
                                 } else if (window.jQuery) {
                                     window.jQuery(modalEl).modal('hide');
                                 }
                             }
+                            document.querySelectorAll('.modal-backdrop').forEach((backdrop) => backdrop.remove());
+                            document.body.classList.remove('modal-open');
+                            document.body.style.removeProperty('overflow');
+                            document.body.style.removeProperty('padding-right');
                             this.destroyCropper();
                         });
                     },


### PR DESCRIPTION
## Summary
- dispose of the Bootstrap modal instance when the media editor closes
- remove any lingering modal backdrop elements and reset body styles after closing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e03d8a9aa8832ebeda92346e410966