### PR TITLE
Fix lingering backdrop when reopening media editor modal

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -329,6 +329,13 @@
                             const modalEl = document.getElementById('mediaEditorModal');
                             let modalInstance = null;
                             if (modalEl) {
+                                document
+                                    .querySelectorAll('.modal-backdrop')
+                                    .forEach((backdrop) => backdrop.remove());
+                                document.body.classList.remove('modal-open');
+                                document.body.style.removeProperty('overflow');
+                                document.body.style.removeProperty('padding-right');
+
                                 if (window.bootstrap && window.bootstrap.Modal) {
                                     modalInstance = new bootstrap.Modal(modalEl);
                                     modalInstance.show();


### PR DESCRIPTION
## Summary
- remove existing modal backdrops and body styles before showing the media editor modal to avoid a stuck overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e03f0ee324832eabae1293124ad3d8