### PR TITLE
Fix media editor close handling

### DIFF
--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -156,6 +156,12 @@ class MediaLibrary extends Component
         $this->resetPage();
     }
 
+    #[On('mediaEditorCancel')]
+    public function cancelEditing(): void
+    {
+        $this->resetEditing();
+    }
+
     #[On('mediaEditorSave')]
     public function saveMediaEditor($payload = []): void
     {

--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -166,9 +166,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">Edit Media</h5>
-                    <button type="button" class="close" data-bs-dismiss="modal" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close" aria-label="Close" x-on:click.prevent="closeEditor()"></button>
                 </div>
                 <div class="modal-body">
                     <div class="row g-4">
@@ -223,7 +221,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" x-on:click.prevent="closeEditor()">Close</button>
                     <button type="button" class="btn btn-primary" x-on:click="saveChanges()">Save changes</button>
                 </div>
             </div>
@@ -445,6 +443,25 @@
                             this.resizeHeight = Math.round(data.height);
                             this.dimensions = `${this.resizeWidth}×${this.resizeHeight}`;
                             this.suppressRatioUpdate = false;
+                        }
+                    },
+                    closeEditor() {
+                        window.dispatchEvent(new CustomEvent('mediaEditorClosed'));
+
+                        if (this.$wire && typeof this.$wire.call === 'function') {
+                            this.$wire.call('cancelEditing');
+                            return;
+                        }
+
+                        if (typeof Livewire !== 'undefined') {
+                            if (typeof Livewire.dispatch === 'function') {
+                                Livewire.dispatch('mediaEditorCancel');
+                                return;
+                            }
+
+                            if (typeof Livewire.emit === 'function') {
+                                Livewire.emit('mediaEditorCancel');
+                            }
                         }
                     },
                     saveChanges() {


### PR DESCRIPTION
## Summary
- add a Livewire cancel handler so closing the editor resets component state
- wire the modal close controls through an Alpine helper that hides the modal reliably

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e046137c88832e90f0ae95b3a57733