### PR TITLE
Ensure modal backdrop cleaned after Livewire updates

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -319,6 +319,12 @@
                             document.body.removeAttribute('data-bs-padding-right');
                         };
 
+                        if (typeof Livewire !== 'undefined' && typeof Livewire.hook === 'function') {
+                            Livewire.hook('message.processed', () => {
+                                cleanupModalArtifacts();
+                            });
+                        }
+
                         window.addEventListener('openMediaEditor', (event) => {
                             const detail = event.detail || {};
                             this.mediaId = detail.id || null;


### PR DESCRIPTION
## Summary
- hook into Livewire's message lifecycle to run modal cleanup logic
- ensure lingering Bootstrap modal backdrops are removed after updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e04c2d94d4832e81736f20ed1d2c19