### PR TITLE
Ensure Livewire modal cleanup runs after initialization

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -319,11 +319,30 @@
                             document.body.removeAttribute('data-bs-padding-right');
                         };
 
-                        if (typeof Livewire !== 'undefined' && typeof Livewire.hook === 'function') {
+                        let livewireCleanupHookRegistered = false;
+                        const registerLivewireCleanupHook = () => {
+                            if (livewireCleanupHookRegistered) {
+                                return;
+                            }
+
+                            if (typeof Livewire === 'undefined' || typeof Livewire.hook !== 'function') {
+                                return;
+                            }
+
                             Livewire.hook('message.processed', () => {
                                 cleanupModalArtifacts();
                             });
-                        }
+                            livewireCleanupHookRegistered = true;
+                        };
+
+                        registerLivewireCleanupHook();
+
+                        const livewireInitHandler = () => {
+                            registerLivewireCleanupHook();
+                        };
+
+                        window.addEventListener('livewire:init', livewireInitHandler, { once: true });
+                        window.addEventListener('livewire:load', livewireInitHandler, { once: true });
 
                         window.addEventListener('openMediaEditor', (event) => {
                             const detail = event.detail || {};


### PR DESCRIPTION
## Summary
- defer registration of the media library modal cleanup hook until Livewire is ready
- guard against registering the cleanup hook multiple times to avoid duplicate listeners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e04d2169c8832ebebd2504b63ba1c7