### PR TITLE
Ensure media editor modal backdrops are cleaned up

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -320,6 +320,7 @@
                         };
 
                         let livewireCleanupHookRegistered = false;
+                        let pendingCleanupTimeout = null;
                         const registerLivewireCleanupHook = () => {
                             if (livewireCleanupHookRegistered) {
                                 return;
@@ -429,6 +430,15 @@
                             }
 
                             this.destroyCropper();
+
+                            if (pendingCleanupTimeout) {
+                                clearTimeout(pendingCleanupTimeout);
+                            }
+
+                            pendingCleanupTimeout = window.setTimeout(() => {
+                                pendingCleanupTimeout = null;
+                                cleanupModalArtifacts();
+                            }, 500);
                         });
                     },
                     handleDrop(event) {


### PR DESCRIPTION
## Summary
- add a deferred cleanup pass to remove lingering Bootstrap modal artifacts when the media editor closes
- prevent duplicate timers while ensuring modal backdrops are fully cleared after Livewire updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e04e2e213c832e9336cffcf808344b