### PR TITLE
Ensure modal backdrop is hidden before cleanup

### DIFF
--- a/resources/views/livewire/admin/media-library.blade.php
+++ b/resources/views/livewire/admin/media-library.blade.php
@@ -311,7 +311,10 @@
                         const cleanupModalArtifacts = () => {
                             document
                                 .querySelectorAll('.modal-backdrop')
-                                .forEach((backdrop) => backdrop.remove());
+                                .forEach((backdrop) => {
+                                    backdrop.style.setProperty('display', 'none', 'important');
+                                    backdrop.remove();
+                                });
                             document.body.classList.remove('modal-open');
                             document.body.style.removeProperty('overflow');
                             document.body.style.removeProperty('padding-right');


### PR DESCRIPTION
## Summary
- ensure the media library modal cleanup explicitly hides any remaining backdrops before removing them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e04f0bbafc832ea390c5fad87f0d55