### PR TITLE
Fix media library selection mode initialization

### DIFF
--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -65,6 +65,11 @@ class MediaLibrary extends Component
         'uploads.*.max' => 'Each file must be 15MB or less.',
     ];
 
+    public function mount(bool $selectionEnabled = false): void
+    {
+        $this->selectionEnabled = $selectionEnabled;
+    }
+
     public function updatingSearch(): void
     {
         $this->resetPage();


### PR DESCRIPTION
## Summary
- ensure the admin media library component respects the selection-enabled flag by persisting it during mounting

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e279a1ea40832eaf201130c36cf0f3