### PR TITLE
Ensure media library buttons initialize reliably

### DIFF
--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -269,7 +269,16 @@
 @pushOnce('scripts')
     <script src="{{ asset('ckeditor/ckeditor.js') }}"></script>
     <script>
-        document.addEventListener('livewire:init', () => {
+        const initializePostFormEnhancements = () => {
+            if (window.__postFormEnhancementsInitialized) {
+                return;
+            }
+
+            if (typeof window.Livewire === 'undefined') {
+                return;
+            }
+
+            window.__postFormEnhancementsInitialized = true;
             const debounce = (callback, wait = 300) => {
                 let timeoutId;
 
@@ -608,6 +617,13 @@
                     window.jQuery(modalEl).on('hidden.bs.modal', () => dispatchToLivewire('closeMediaSelector'));
                 }
             }
-        });
+        };
+
+        window.addEventListener('livewire:init', initializePostFormEnhancements, { once: true });
+        window.addEventListener('livewire:load', initializePostFormEnhancements, { once: true });
+
+        if (typeof window.Livewire !== 'undefined') {
+            initializePostFormEnhancements();
+        }
     </script>
 @endpushOnce


### PR DESCRIPTION
## Summary
- guard the post form media library/CKEditor script so it only boots once Livewire is available
- register initialization for both `livewire:init` and `livewire:load` events and run immediately when Livewire is already ready

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e27b2499a4832e9c412274e28bf2a6