### PR TITLE
Add editable permalink controls for post form

### DIFF
--- a/app/Livewire/Admin/PostForm.php
+++ b/app/Livewire/Admin/PostForm.php
@@ -47,6 +47,9 @@ class PostForm extends Component
     public ?string $existingThumbnail = null;
 
     public bool $autoGenerateSlug = true;
+    public bool $isEditingSlug = false;
+    public bool $autoGenerateSlugBeforeEdit = true;
+    public ?string $slugBeforeEdit = null;
 
     protected ?string $lastSyncedDescription = null;
 
@@ -82,6 +85,8 @@ class PostForm extends Component
         }
 
         $this->lastSyncedDescription = $this->description;
+        $this->autoGenerateSlugBeforeEdit = $this->autoGenerateSlug;
+        $this->slugBeforeEdit = $this->slug;
     }
 
     public function updatedTitle($value): void
@@ -103,6 +108,52 @@ class PostForm extends Component
     {
         $this->autoGenerateSlug = false;
         $this->slug = $this->generateUniqueSlug($value ?: $this->title);
+    }
+
+    public function startSlugEditing(): void
+    {
+        if ($this->isEditingSlug) {
+            return;
+        }
+
+        $this->autoGenerateSlugBeforeEdit = $this->autoGenerateSlug;
+        $this->slugBeforeEdit = $this->slug;
+
+        if ($this->slug === '' && $this->title) {
+            $this->slug = $this->generateUniqueSlug($this->title);
+        }
+
+        $this->autoGenerateSlug = false;
+        $this->isEditingSlug = true;
+    }
+
+    public function cancelSlugEditing(): void
+    {
+        $this->slug = $this->slugBeforeEdit ?? $this->slug;
+        $this->isEditingSlug = false;
+        $this->autoGenerateSlug = $this->autoGenerateSlugBeforeEdit;
+
+        if ($this->autoGenerateSlug) {
+            $this->slug = $this->generateUniqueSlug($this->title);
+        }
+    }
+
+    public function saveSlugEdit(): void
+    {
+        $this->slug = $this->generateUniqueSlug($this->slug ?: $this->title);
+        $this->slugBeforeEdit = $this->slug;
+        $this->autoGenerateSlug = false;
+        $this->autoGenerateSlugBeforeEdit = false;
+        $this->isEditingSlug = false;
+    }
+
+    public function resetSlugToAuto(): void
+    {
+        $this->autoGenerateSlug = true;
+        $this->isEditingSlug = false;
+        $this->slug = $this->generateUniqueSlug($this->title);
+        $this->slugBeforeEdit = $this->slug;
+        $this->autoGenerateSlugBeforeEdit = true;
     }
 
     public function updatedContentType($value): void

--- a/resources/views/livewire/admin/post-form.blade.php
+++ b/resources/views/livewire/admin/post-form.blade.php
@@ -11,10 +11,36 @@
                     @enderror
                 </div>
                 <div class="form-group col-md-3">
-                    <label for="postSlug">Slug</label>
-                    <input type="text" id="postSlug" class="form-control @error('slug') is-invalid @enderror" wire:model.defer="slug" placeholder="Auto generated from title">
+                    <label class="d-flex justify-content-between align-items-center" for="postSlug">
+                        <span>Permalink</span>
+                        @if (! $autoGenerateSlug)
+                            <button type="button" class="btn btn-sm btn-link p-0" wire:click="resetSlugToAuto" wire:loading.attr="disabled">
+                                Reset to auto
+                            </button>
+                        @endif
+                    </label>
+                    <div class="border rounded px-3 py-2 bg-light">
+                        <p class="small mb-1 text-break">
+                            <span class="text-muted">{{ url('news') }}/</span>
+                            <span class="text-body font-weight-semibold">{{ $slug ?: 'your-slug' }}</span>
+                        </p>
+                        @if (! $isEditingSlug)
+                            <button type="button" class="btn btn-sm btn-outline-secondary mt-2" wire:click="startSlugEditing" wire:loading.attr="disabled">
+                                Edit permalink
+                            </button>
+                        @endif
+                    </div>
+                    @if ($isEditingSlug)
+                        <div class="mt-2">
+                            <input type="text" id="postSlug" class="form-control @error('slug') is-invalid @enderror" wire:model.defer="slug" placeholder="custom-slug">
+                            <div class="d-flex flex-wrap gap-2 mt-2">
+                                <button type="button" class="btn btn-sm btn-primary" wire:click="saveSlugEdit" wire:loading.attr="disabled">Save</button>
+                                <button type="button" class="btn btn-sm btn-link text-danger" wire:click="cancelSlugEditing" wire:loading.attr="disabled">Cancel</button>
+                            </div>
+                        </div>
+                    @endif
                     @error('slug')
-                        <div class="invalid-feedback">{{ $message }}</div>
+                        <div class="invalid-feedback d-block">{{ $message }}</div>
                     @enderror
                 </div>
                 <div class="form-group col-md-3">


### PR DESCRIPTION
## Summary
- add stateful Livewire helpers to toggle permalink editing and reset behaviour
- refresh the admin post form UI with a permalink preview and edit/cancel workflow

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e32cdacbc4832ebcebaba18d7d3ba8