### PR TITLE
Add guards before querying general settings table

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -5,6 +5,7 @@ use App\Models\Post;
 use App\Models\Setting;
 use App\Support\PermalinkManager;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
 
 if (!function_exists('settings')) {
     function settings($key = null) {
@@ -28,6 +29,10 @@ if (!function_exists('general_settings')) {
     {
         // 1 day cache duration
         $duration = 60 * 60 * 24;
+
+        if (! Schema::hasTable('general_settings')) {
+            return null;
+        }
 
         $settings = Cache::remember('general_settings', $duration, function () {
             return GeneralSetting::first();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Support\BanglaFormatter;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\View;
@@ -44,10 +45,14 @@ class AppServiceProvider extends ServiceProvider
         // $settings, $logoUrl, $navCategories, $currentDateBangla এই ভেরিয়েবলগুলো টার্গেট করা হয়েছে।
         View::composer(['front.partials.header', 'front.partials.footer', 'front.partials.sidebar', 'layouts.frontend'], function ($view) {
 
-            // সেটিংস ডেটা (ক্যাশিং সহ)
-            $settings = Cache::remember('general_settings', now()->addHour(), function () {
-                return GeneralSetting::query()->first();
-            });
+            // সেটিংস ডেটা (ক্যাশিং সহ) — টেবিল না থাকলে বা কনসোলে চললে স্কিপ
+            $settings = null;
+
+            if (! $this->app->runningInConsole() && Schema::hasTable('general_settings')) {
+                $settings = Cache::remember('general_settings', now()->addHour(), function () {
+                    return GeneralSetting::query()->first();
+                });
+            }
 
             $logoUrl = null;
             if ($settings?->site_logo) {


### PR DESCRIPTION
## Summary
- skip general settings queries during boot when running in console or the table is missing
- avoid querying general settings helper before the table exists

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69214f0ee494832593778b6895d4d328)